### PR TITLE
Using NSDataStream instead of byte[]

### DIFF
--- a/src/ModernHttpClient.iOS/AFNetworkHandler.cs
+++ b/src/ModernHttpClient.iOS/AFNetworkHandler.cs
@@ -59,7 +59,7 @@ namespace ModernHttpClient
             }
 
             var ret = new HttpResponseMessage((HttpStatusCode)resp.StatusCode) {
-                Content = new ByteArrayContent(op.ResponseData.ToArray()),
+                Content = new StreamContent(new NSDataStream(op.ResponseData)),
                 RequestMessage = request,
                 ReasonPhrase = (err != null ? err.LocalizedDescription : null),
             };
@@ -112,24 +112,23 @@ namespace ModernHttpClient
         }
     }
 
-    class ByteArrayHttpContent : HttpContent
-    {
-        byte[] data;
-        public ByteArrayHttpContent(byte[] data)
-        {
-            this.data = data;
-        }
+	unsafe class NSDataStream : UnmanagedMemoryStream
+	{
+		public NSDataStream(NSData data)
+			: base((byte*)data.Bytes, data.Length)
+		{
+			_data = data;
+		}
 
-        protected override async Task SerializeToStreamAsync(Stream stream, TransportContext context)
-        {
-            await (new MemoryStream(data)).CopyToAsync(stream);
-        }
+		private readonly NSData _data;
 
-        protected override bool TryComputeLength(out long length)
-        {
-            length = data.Length;
-            return true;
-        }
-    }
+		protected override void Dispose(bool disposing)
+		{
+			if (disposing)
+				_data.Dispose();
+
+			base.Dispose(disposing);
+		}
+	}
 }
 

--- a/src/ModernHttpClient.iOS/ModernHttpClient.iOS.csproj
+++ b/src/ModernHttpClient.iOS/ModernHttpClient.iOS.csproj
@@ -1,4 +1,4 @@
-<?xml version="1.0" encoding="utf-8"?>
+﻿<?xml version="1.0" encoding="utf-8"?>
 <Project DefaultTargets="Build" ToolsVersion="4.0" xmlns="http://schemas.microsoft.com/developer/msbuild/2003">
   <PropertyGroup>
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
@@ -21,6 +21,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
     <DebugType>full</DebugType>
@@ -29,6 +30,7 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
+    <AllowUnsafeBlocks>true</AllowUnsafeBlocks>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -41,7 +43,7 @@
     <Folder Include="Resources\" />
     <Folder Include="Properties\" />
   </ItemGroup>
-  <Import Project="$(MSBuildBinPath)\Microsoft.CSharp.targets" />
+  <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
     <ProjectReference Include="..\..\vendor\afnetworking\AFNetworking\AFNetworking.csproj">
       <Project>{8736B208-9B6B-4B35-9817-04106F2DAF88}</Project>


### PR DESCRIPTION
Changed to use NSDataStream instead of using byte[] to prevent unnecessary reading of the stream ahead of time when NSData is converted to byte[] before being put back in Content.
