### PR TITLE
Updated to correct some "bad URL" errors that were being thrown

### DIFF
--- a/src/ModernHttpClient.iOS/AFNetworkHandler.cs
+++ b/src/ModernHttpClient.iOS/AFNetworkHandler.cs
@@ -32,7 +32,7 @@ namespace ModernHttpClient
                     return acc;
                 }),
                 HttpMethod = request.Method.ToString().ToUpperInvariant(),
-                Url = new NSUrl(request.RequestUri.ToString()),
+                Url = NSUrl.FromString(request.RequestUri.AbsoluteUri),
             };
 
             var host = request.RequestUri.GetLeftPart(UriPartial.Authority);


### PR DESCRIPTION
"bad URL" were being thrown when a space appeared in any part of the URL. [NSUrl URLWithString:] properly encodes the URI.
