### PR TITLE
Throw WebException if no internet connection

### DIFF
--- a/src/ModernHttpClient.iOS/AFNetworkHandler.cs
+++ b/src/ModernHttpClient.iOS/AFNetworkHandler.cs
@@ -56,6 +56,10 @@ namespace ModernHttpClient
 
             var resp = (NSHttpUrlResponse)op.Response;
 
+            if (err != null && resp == null && err.Domain == NSError.NSUrlErrorDomain && err.Code == -1009) {
+                throw new WebException (err.LocalizedDescription, WebExceptionStatus.NameResolutionFailure);
+            }
+
             if (op.IsCancelled) {
                 lock (pins) { pins.Remove(rq); }
                 throw new TaskCanceledException();


### PR DESCRIPTION
Currently if no internet connection, then SendAsync method throw NullReferenceException.
Default HttpClient throws `WebException(WebExceptionStatus.NameResolutionFailure)`.
