### PR TITLE
Fixed determination of WebException

### DIFF
--- a/src/ModernHttpClient.iOS/AFNetworkHandler.cs
+++ b/src/ModernHttpClient.iOS/AFNetworkHandler.cs
@@ -69,7 +69,7 @@ namespace ModernHttpClient
 
             var resp = (NSHttpUrlResponse)op.Response;
 
-            if (err != null && resp == null && err.Domain == NSError.NSUrlErrorDomain && err.Code == -1009) {
+            if (err != null && resp == null && err.Domain == NSError.NSUrlErrorDomain) {
                 throw new WebException (err.LocalizedDescription, WebExceptionStatus.NameResolutionFailure);
             }
 


### PR DESCRIPTION
There should not be the check of the `error.Code`.
