### PR TITLE
Add Internet permission to HttpClient sample too.

### DIFF
--- a/samples/HttpClient.Android/Properties/AndroidManifest.xml
+++ b/samples/HttpClient.Android/Properties/AndroidManifest.xml
@@ -3,4 +3,5 @@
 	<uses-sdk android:minSdkVersion="8" />
 	<application android:label="HttpClient.Android">
 	</application>
+    <uses-permission android:name="android.permission.INTERNET" />
 </manifest>


### PR DESCRIPTION
This will make it work under Release profile, avoiding an exception
when sending a request with okhttp.
