### PR TITLE
Fixed issue with empty response body.

### DIFF
--- a/src/ModernHttpClient.iOS/AFNetworkHandler.cs
+++ b/src/ModernHttpClient.iOS/AFNetworkHandler.cs
@@ -121,7 +121,14 @@ namespace ModernHttpClient
             });
 
             operation.SetCompletionBlockWithSuccess(
-                (op, _) => onCompleted(),
+                (op, _) => {                    
+                    if (!completed)
+                    {
+                        completed = true;
+                        tcs.SetResult(operation);
+                    }
+                    onCompleted();
+                },
                 (op, err) => {
                     var ex = new ApplicationException();
                     ex.Data.Add("op", op);


### PR DESCRIPTION
Fixed issue - if a response has an empty body then the task result is not set. 
