### PR TITLE
Ensure no concurrent access to NSMutableData

### DIFF
--- a/src/ModernHttpClient.Android/ModernHttpClient.Android.csproj
+++ b/src/ModernHttpClient.Android/ModernHttpClient.Android.csproj
@@ -65,6 +65,9 @@
     <Compile Include="..\Shared\ConcatenatingStream.cs">
       <Link>ConcatenatingStream.cs</Link>
     </Compile>
+    <Compile Include="..\Shared\AsyncLock.cs">
+      <Link>AsyncLock.cs</Link>
+    </Compile>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/src/ModernHttpClient.iOS/ModernHttpClient.iOS.csproj
+++ b/src/ModernHttpClient.iOS/ModernHttpClient.iOS.csproj
@@ -17,7 +17,7 @@
     <DebugType>full</DebugType>
     <Optimize>false</Optimize>
     <OutputPath>bin\Debug</OutputPath>
-    <DefineConstants>DEBUG;</DefineConstants>
+    <DefineConstants>DEBUG; UIKIT</DefineConstants>
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <ConsolePause>false</ConsolePause>
@@ -29,7 +29,6 @@
     </CustomCommands>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|AnyCPU' ">
-    <DebugType>full</DebugType>
     <Optimize>true</Optimize>
     <OutputPath>bin\Release</OutputPath>
     <ErrorReport>prompt</ErrorReport>
@@ -41,6 +40,7 @@
         <Command type="BeforeBuild" command="make AFNetworking.dll" workingdir="${SolutionDir}" />
       </CustomCommands>
     </CustomCommands>
+    <DefineConstants>UIKIT</DefineConstants>
   </PropertyGroup>
   <Import Project="$(MSBuildExtensionsPath)\Xamarin\iOS\Xamarin.MonoTouch.CSharp.targets" />
   <ItemGroup>
@@ -58,6 +58,9 @@
     </Reference>
     <Compile Include="..\Shared\ConcatenatingStream.cs">
       <Link>ConcatenatingStream.cs</Link>
+    </Compile>
+    <Compile Include="..\Shared\AsyncLock.cs">
+      <Link>AsyncLock.cs</Link>
     </Compile>
   </ItemGroup>
 </Project>

--- a/src/Shared/AsyncLock.cs
+++ b/src/Shared/AsyncLock.cs
@@ -1,0 +1,35 @@
+﻿using System;
+using System.Threading.Tasks;
+using System.Threading;
+
+namespace ModernHttpClient
+{
+    // Straight-up thieved from http://www.hanselman.com/blog/ComparingTwoTechniquesInNETAsynchronousCoordinationPrimitives.aspx 
+    public sealed class AsyncLock
+    {
+        readonly SemaphoreSlim m_semaphore = new SemaphoreSlim(1, 1);
+        readonly Task<IDisposable> m_releaser;
+
+        public AsyncLock()
+        {
+            m_releaser = Task.FromResult((IDisposable)new Releaser(this));
+        }
+
+        public Task<IDisposable> LockAsync()
+        {
+            var wait = m_semaphore.WaitAsync();
+            return wait.IsCompleted ?
+                m_releaser :
+                wait.ContinueWith((_, state) => (IDisposable)state,
+                    m_releaser.Result, CancellationToken.None,
+                    TaskContinuationOptions.ExecuteSynchronously, TaskScheduler.Default);
+        }
+
+        sealed class Releaser : IDisposable
+        {
+            readonly AsyncLock m_toRelease;
+            internal Releaser(AsyncLock toRelease) { m_toRelease = toRelease; }
+            public void Dispose() { m_toRelease.m_semaphore.Release(); }
+        }
+    }
+}


### PR DESCRIPTION
I'm pretty sure that this is a bug in Xamarin.iOS because we never write to the NSMutableData, but just for funsies, synchronize access to the underlying stream. Fixes #22, maybe.
