### PR TITLE
Added headers for the HttpContent, provides access to Content-Type heade...

### DIFF
--- a/src/ModernHttpClient.iOS/AFNetworkHandler.cs
+++ b/src/ModernHttpClient.iOS/AFNetworkHandler.cs
@@ -94,6 +94,7 @@ namespace ModernHttpClient
 
             foreach(var v in resp.AllHeaderFields) {
                 ret.Headers.TryAddWithoutValidation(v.Key.ToString(), v.Value.ToString());
+                ret.Content.Headers.TryAddWithoutValidation(v.Key.ToString(), v.Value.ToString());
             }
 
             lock (pins) { pins.Remove(rq); }


### PR DESCRIPTION
Fix issue where content-type isn't in header collection of response object.

Some headers are split into the content object instead of just being on the request, tryAdd knows which ones go where and will only add them to the appropriate headers collection. 

See method TryAddWithoutValidation at line 229:
https://github.com/mono/mono/blob/13899a5658da8baddd20d11ad1542163e59cbde5/mcs/class/System.Net.Http/System.Net.Http.Headers/HttpHeaders.cs
