### PR TITLE
Fix Android Exceptions for URI chars and DNS

### DIFF
--- a/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs
@@ -24,8 +24,14 @@ namespace ModernHttpClient
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
-            var url = new Java.Net.URL(request.RequestUri.ToString());
-            var rq = client.Open(url);
+            var java_uri = request.RequestUri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);
+            var url = new Java.Net.URL(java_uri);
+            Java.Net.HttpURLConnection rq;
+            try {
+                rq = client.Open(url);
+            } catch(Java.Net.UnknownHostException e) {
+                throw new WebException("Name resolution failure", e, WebExceptionStatus.NameResolutionFailure, null);
+            }
             rq.RequestMethod = request.Method.Method.ToUpperInvariant();
 
             foreach (var kvp in request.Headers) { rq.SetRequestProperty(kvp.Key, kvp.Value.FirstOrDefault()); }


### PR DESCRIPTION
1. remap unknown host exception to .net web exceptions.  
2. pass an encoded uri to java to avoid invalid character exceptions
