### PR TITLE
Fix UnknownHostException in OkHttpNetworkHandler

### DIFF
--- a/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs
@@ -48,8 +48,13 @@ namespace ModernHttpClient
             }
 
             return await Task.Run (() => {
+                HttpResponseMessage ret;
                 // NB: This is the line that blocks until we have headers
-                var ret = new HttpResponseMessage((HttpStatusCode)rq.ResponseCode);
+                try {
+                    ret = new HttpResponseMessage((HttpStatusCode)rq.ResponseCode);
+                } catch(Java.Net.UnknownHostException e) {
+                    throw new WebException("Name resolution failure", e, WebExceptionStatus.NameResolutionFailure, null);
+                }
 
                 // Test to see if we're being redirected (i.e. in a captive network)
                 if (throwOnCaptiveNetwork && (url.Host != rq.URL.Host)) {


### PR DESCRIPTION
03-03 09:12:33.444 I/MonoDroid( 2255): UNHANDLED EXCEPTION: Java.Net.UnknownHostException: Exception of type 'Java.Net.UnknownHostException' was thrown.
03-03 09:12:33.444 I/MonoDroid( 2255):   at Android.Runtime.JNIEnv.CallIntMethod (IntPtr jobject, IntPtr jmethod) [0x00063] in /Users/builder/data/lanes/monodroid-mlion-monodroid-4.10.2-branch/e0ba8107/source/monodroid/src/Mono.Android/src/Runtime/JNIEnv.g.cs:350 
03-03 09:12:33.444 I/MonoDroid( 2255):   at Java.Net.HttpURLConnection.get_ResponseCode () [0x00043] in /Users/builder/data/lanes/monodroid-mlion-monodroid-4.10.2-branch/e0ba8107/source/monodroid/src/Mono.Android/platforms/android-14/src/generated/Java.Net.HttpURLConnection.cs:499 
03-03 09:12:33.444 I/MonoDroid( 2255):   at ModernHttpClient.OkHttpNetworkHandler+<SendAsync>c__async0+<SendAsync>c__AnonStorey9.<>m__1 () [0x00019] in /Users/paul/code/paulcbetts/ModernHttpClient/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs:52 
03-03 09:12:33.444 I/MonoDroid( 2255):   at System.Threading.Tasks.TaskActionInvoker+FuncInvoke`1[System.Net.Http.HttpResponseMessage].Invoke (System.Threading.Tasks.Task owner, System.Object state, System.Threading.Tasks.Task context) [0x00000] in <filename unknown>:0 
03-03 09:12:33.444 I/MonoDroid( 2255):   at System.Threading.Tasks.Task.InnerInvoke () [0x00000] in <filename unknown>:0 
03-03 09:12:33.444 I/MonoDroid( 2255):   at System.Threading.Tasks.Task.ThreadStart () [0x00000] in <filename unknown>:0 
...
