### PR TITLE
handle connection failure (timeout,...)

### DIFF
--- a/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs
@@ -55,6 +55,8 @@ namespace ModernHttpClient
                     ret = new HttpResponseMessage((HttpStatusCode)rq.ResponseCode);
                 } catch(Java.Net.UnknownHostException e) {
                     throw new WebException("Name resolution failure", e, WebExceptionStatus.NameResolutionFailure, null);
+                } catch(Java.Net.ConnectException e) {
+                    throw new WebException("Connection failed", e, WebExceptionStatus.ConnectFailure, null);
                 }
 
                 // Test to see if we're being redirected (i.e. in a captive network)


### PR DESCRIPTION
04-07 03:52:34.684 I/MonoDroid( 2011): UNHANDLED EXCEPTION: Java.Net.ConnectException: Exception of type 'Java.Net.ConnectException' was thrown.
04-07 03:52:34.684 I/MonoDroid( 2011):   at Android.Runtime.JNIEnv.CallIntMethod (IntPtr jobject, IntPtr jmethod) [0x00000] in <filename unknown>:0 
04-07 03:52:34.684 I/MonoDroid( 2011):   at Java.Net.HttpURLConnection.get_ResponseCode () [0x00000] in <filename unknown>:0 
04-07 03:52:34.684 I/MonoDroid( 2011):   at ModernHttpClient.OkHttpNetworkHandler+<SendAsync>c__async0+<SendAsync>c__AnonStorey8.<>m__1 () [0x00020] in /Users/paul/code/paulcbetts/ModernHttpClient/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs:55 
04-07 03:52:34.684 I/MonoDroid( 2011):   at System.Threading.Tasks.TaskActionInvoker+FuncInvoke`1[System.Net.Http.HttpResponseMessage].Invoke (System.Threading.Tasks.Task owner, System.Object state, System.Threading.Tasks.Task context) [0x00000] in <filename unknown>:0 
04-07 03:52:34.684 I/04-07 03:52:34.684 I/MonoDroid( 2011):   at System.Threading.Tasks.Task.InnerInvoke () [0x00000] in <filename unknown>:0 
04-07 03:52:34.684 I/MonoDroid( 2011):   at System.Threading.Tasks.Task.ThreadStart () [0x00000] in <filename unknown>:0 
04-07 03:52:34.684 I/MonoDroid( 2011): --- End of stack trace from previous location where exception was thrown ---
04-07 03:52:34.684 I/MonoDroid( 2011):   at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x00000] in <filename unknown>:0 
04-07 03:52:34.684 I/MonoDroid( 2011):   at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[System.Net.Http.HttpResponseMessage].GetResult () [0x00000] in <filename unknown>:0 
04-07 03:52:34.684 I/MonoDroid( 2011):   at ModernHttpClient.OkHttpNetworkHandler+<SendAsync>c__async0.MoveNext () [0x002a8] in /Users/paul/code/paulcbetts/ModernHttpClient/src/ModernHttpClient.Android/OkHttpNetworkHandler.cs:50 
04-07 03:52:34.684 I/MonoDroid( 2011): --- End of stack trace from previous location where exception was thrown ---

libcore.io.ErrnoException: connect failed: ETIMEDOUT (Connection timed out)

Other ideas
- Catching IOException could be safier
- Extract more information from java's exception to give a more specific message and status
