### PR TITLE
Fixed issue with duplicated Http Headers

### DIFF
--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -75,10 +75,9 @@ namespace ModernHttpClient
             var keyValuePairs = request.Headers
                 .Union(request.Content != null ?
                     (IEnumerable<KeyValuePair<string, IEnumerable<string>>>)request.Content.Headers :
-                    Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>())
-                .SelectMany(x => x.Value.Select(val => new { Key = x.Key, Value = val }));
+                    Enumerable.Empty<KeyValuePair<string, IEnumerable<string>>>());
 
-            foreach (var kvp in keyValuePairs) builder.AddHeader(kvp.Key, kvp.Value);
+            foreach (var kvp in keyValuePairs) builder.AddHeader(kvp.Key, String.Join(",", kvp.Value));
 
             cancellationToken.ThrowIfCancellationRequested();
 

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -90,7 +90,7 @@ namespace ModernHttpClient
                 Body = NSData.FromArray(ms.ToArray()),
                 CachePolicy = NSUrlRequestCachePolicy.UseProtocolCachePolicy,
                 Headers = headers.Aggregate(new NSMutableDictionary(), (acc, x) => {
-                    acc.Add(new NSString(x.Key), new NSString(x.Value.LastOrDefault()));
+                    acc.Add(new NSString(x.Key), new NSString(String.Join(",", x.Value)));
                     return acc;
                 }),
                 HttpMethod = request.Method.ToString().ToUpperInvariant(),


### PR DESCRIPTION
When a header was having multiple values, the iOS solution was to pick the last, and the Android solution was to create multiple headers.

I believe the correct behavior is to separate each value with a comma. 

**Example:**

In the current implementation I was getting `400 - Bad Request` responses because of the headers being sent from my Android device looked like this:

```
User-Agent: Android/4.1.1
User-Agent: Music.Droid.Msh/1.0.0.0
User-Agent: Rev/local
User-Agent: E247.Api.Client/0.1.0.157
User-Agent: (Google Nexus 4 - 4.1.1 - API 16 - 768x1280 vbox86p)
Accept-Language: en-US
Accept-Encoding: gzip
Accept-Encoding: deflate
```

With the suggested changes the headers would render like this:

```
User-Agent: Android/4.1.1,Music.Droid.Msh/1.0.0.0,Rev/local,E247.Api.Client/0.1.0.157,(Google Nexus 4 - 4.1.1 - API 16 - 768x1280 vbox86p)
Accept-Language: en-US
Accept-Encoding: gzip,deflate
```
