### PR TITLE
Fix for captive networks on Android

### DIFF
--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -90,6 +90,13 @@ namespace ModernHttpClient
             var resp = default(Response);
             try {
                 resp = await call.EnqueueAsync().ConfigureAwait(false);
+                var newReq = resp.Request();
+                var newUri = newReq == null ? null : newReq.Uri();
+                if (throwOnCaptiveNetwork && newUri != null) {
+                    if (url.Host != newUri.Host) {
+                        throw new CaptiveNetworkException(new Uri(java_uri), new Uri(newUri.ToString()));
+                    }
+                }
             } catch (IOException ex) {
                 if (ex.Message.ToLowerInvariant().Contains("canceled")) {
                     throw new OperationCanceledException();

--- a/src/ModernHttpClient/ModernHttpClient.Android.csproj
+++ b/src/ModernHttpClient/ModernHttpClient.Android.csproj
@@ -58,6 +58,7 @@
       <HintPath>..\..\vendor\okhttp\OkHttp.dll</HintPath>
     </Reference>
     <Compile Include="Utility.cs" />
+    <Compile Include="CaptiveNetworkException.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>


### PR DESCRIPTION
Hi Paul,

This is the fix for Captive Network on Android.
It adds the class to the Android project so issue #89 is fixed. But it also handles captive network detection and throws now the exception.
