### PR TITLE
Cancel request on certificate verification failed (iOS)

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -287,7 +287,7 @@ namespace ModernHttpClient
                         NSUrlSessionAuthChallengeDisposition.UseCredential,
                         NSUrlCredential.FromTrust(challenge.ProtectionSpace.ServerSecTrust));
                 } else {
-                    completionHandler(NSUrlSessionAuthChallengeDisposition.RejectProtectionSpace, null);
+                    completionHandler(NSUrlSessionAuthChallengeDisposition.CancelAuthenticationChallenge, null);
                 }
                 return;
 


### PR DESCRIPTION
I noticed that the request is not cancelled if ServicePointManager.ServerCertificateValidationCallback returns false
