### PR TITLE
Enable portable cookie handling on iOS and Android.

### DIFF
--- a/src/ModernHttpClient/Android/NativeCookieHandler.cs
+++ b/src/ModernHttpClient/Android/NativeCookieHandler.cs
@@ -1,0 +1,46 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using Java.Net;
+
+namespace ModernHttpClient
+{
+    public class NativeCookieHandler
+    {
+        readonly CookieManager cookieManager = new CookieManager();
+
+        public NativeCookieHandler()
+        {
+            CookieHandler.Default = cookieManager; //set cookie manager if using NativeCookieHandler
+        }
+
+        public void SetCookies(Cookie[] cookies)
+        {
+            cookies.Select(ToNativeCookie).ToList().ForEach(nc => cookieManager.CookieStore.Add(new URI(nc.Domain),nc));
+        }
+            
+        public ICollection<Cookie> Cookies
+        {
+            get 
+            {
+                return cookieManager.CookieStore.Cookies.Select(ToNetCookie).ToList();
+            }
+        }
+
+        static HttpCookie ToNativeCookie(Cookie cookie)
+        {
+            var nc = new HttpCookie(cookie.Name, cookie.Value);
+            nc.Domain = cookie.Domain;
+            nc.Path = cookie.Path;
+            nc.Secure = cookie.Secure;
+            return nc;
+        }
+
+        static Cookie ToNetCookie(HttpCookie cookie)
+        {
+            var nc = new Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain);
+            nc.Secure = cookie.Secure;
+            return nc;
+        }
+    }
+}

--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -25,7 +25,7 @@ namespace ModernHttpClient
 
         public NativeMessageHandler() : this(false, false) {}
 
-        public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification)
+        public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification, NativeCookieHandler cookieHandler = null)
         {
             this.throwOnCaptiveNetwork = throwOnCaptiveNetwork;
 

--- a/src/ModernHttpClient/Facades.cs
+++ b/src/ModernHttpClient/Facades.cs
@@ -3,6 +3,7 @@ using System.Net.Http;
 using System.Threading.Tasks;
 using System.Threading;
 using System.IO;
+using System.Net;
 
 namespace ModernHttpClient
 {
@@ -28,7 +29,9 @@ namespace ModernHttpClient
         /// verification via ServicePointManager. Disabled by default for 
         /// performance reasons (i.e. the OS default certificate verification 
         /// will take place)</param>
-        public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification) : base()
+        /// <param name="cookieHandler">Enable native cookie handling.
+        /// </param>
+        public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification, NativeCookieHandler cookieHandler = null) : base()
         {
         }
 
@@ -59,4 +62,21 @@ namespace ModernHttpClient
     }
 
     public delegate void ProgressDelegate(long bytes, long totalBytes, long totalBytesExpected);
+
+    public class NativeCookieHandler
+    {
+        const string wrongVersion = "You're referencing the Portable version in your App - you need to reference the platform (iOS/Android) version";
+
+        [Obsolete("You're using NativeCookieHandler on an unsupported platform or are ref'ing the wrong DLL. This method will do nothing!")]
+        public void SetCookies(Cookie[] cookies)
+        {
+            throw new Exception(wrongVersion);
+        }
+
+        [Obsolete("You're using NativeCookieHandler on an unsupported platform or are ref'ing the wrong DLL. This method will do nothing!")]
+        public Cookie[] GetCookies()
+        {
+            throw new Exception(wrongVersion);
+        }
+    }
 }

--- a/src/ModernHttpClient/ModernHttpClient.Android.csproj
+++ b/src/ModernHttpClient/ModernHttpClient.Android.csproj
@@ -59,6 +59,7 @@
     </Reference>
     <Compile Include="Utility.cs" />
     <Compile Include="CaptiveNetworkException.cs" />
+    <Compile Include="Android\NativeCookieHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/src/ModernHttpClient/ModernHttpClient.iOS.csproj
+++ b/src/ModernHttpClient/ModernHttpClient.iOS.csproj
@@ -59,6 +59,7 @@
     <Compile Include="CaptiveNetworkException.cs" />
     <Compile Include="ProgressStreamContent.cs" />
     <Compile Include="Utility.cs" />
+    <Compile Include="iOS\NativeCookieHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/ModernHttpClient/ModernHttpClient.iOS64.csproj
+++ b/src/ModernHttpClient/ModernHttpClient.iOS64.csproj
@@ -47,6 +47,7 @@
     <Compile Include="CaptiveNetworkException.cs" />
     <Compile Include="ProgressStreamContent.cs" />
     <Compile Include="Utility.cs" />
+    <Compile Include="iOS\NativeCookieHandler.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -43,7 +43,7 @@ namespace ModernHttpClient
         readonly bool customSSLVerification;
 
         public NativeMessageHandler(): this(false, false) { }
-        public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification)
+        public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification, NativeCookieHandler cookieHandler = null)
         {
             session = NSUrlSession.FromConfiguration(
                 NSUrlSessionConfiguration.DefaultSessionConfiguration, 

--- a/src/ModernHttpClient/iOS/NativeCookieHandler.cs
+++ b/src/ModernHttpClient/iOS/NativeCookieHandler.cs
@@ -1,0 +1,40 @@
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+
+#if UNIFIED
+using Foundation;
+#else
+using MonoTouch.Foundation;
+#endif
+
+namespace ModernHttpClient
+{
+    public class NativeCookieHandler
+    {
+        public void SetCookies(Cookie[] cookies)
+        {
+            cookies.Select(ToNativeCookie).ToList().ForEach(NSHttpCookieStorage.SharedStorage.SetCookie);
+        }
+
+        public ICollection<Cookie> Cookies
+        {
+            get 
+            {
+                return NSHttpCookieStorage.SharedStorage.Cookies.Select(ToNetCookie).ToList();
+            }
+        }
+
+        static NSHttpCookie ToNativeCookie(Cookie cookie)
+        {
+            return new NSHttpCookie(cookie);
+        }
+
+        static Cookie ToNetCookie(NSHttpCookie cookie)
+        {
+            var nc = new Cookie(cookie.Name, cookie.Value, cookie.Path, cookie.Domain);
+            nc.Secure = cookie.IsSecure;
+            return nc;
+        }
+    }
+}


### PR DESCRIPTION
Made native cookie handling possible for iOS and Android, by introducing the NativeCookieHandler class instead of using the (strange) .NET CookieContainer. NativeCookieHandler is set to null by default in order to not break the current API.