### PR TITLE
The request message Response now reflects the redirected url

### DIFF
--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -108,6 +108,7 @@ namespace ModernHttpClient
                 resp = await call.EnqueueAsync().ConfigureAwait(false);
                 var newReq = resp.Request();
                 var newUri = newReq == null ? null : newReq.Uri();
+                request.RequestUri = new Uri(newUri.ToString());
                 if (throwOnCaptiveNetwork && newUri != null) {
                     if (url.Host != newUri.Host) {
                         throw new CaptiveNetworkException(new Uri(java_uri), new Uri(newUri.ToString()));

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -173,6 +173,7 @@ namespace ModernHttpClient
                         Content = content,
                         RequestMessage = data.Request,
                     };
+                    ret.RequestMessage.RequestUri = new Uri(resp.Url.AbsoluteString);
 
                     foreach(var v in resp.AllHeaderFields) {
                         // NB: Cocoa trolling us so hard by giving us back dummy


### PR DESCRIPTION
The following code gives you the redirected url. This fixes ModernHttpClient on iOS to do the same.

var response = await client.GetAsync(url,HttpCompletionOption.ResponseHeadersRead);
response.EnsureSuccessStatusCode();
var redirectUrl =  response.RequestMessage.RequestUri.ToString();