### PR TITLE
Fix race condition in ReadAsync.

### DIFF
--- a/src/ModernHttpClient/iOS/AsyncLock.cs
+++ b/src/ModernHttpClient/iOS/AsyncLock.cs
@@ -7,11 +7,19 @@ namespace ModernHttpClient
     // Straight-up thieved from http://www.hanselman.com/blog/ComparingTwoTechniquesInNETAsynchronousCoordinationPrimitives.aspx 
     public sealed class AsyncLock
     {
-        readonly SemaphoreSlim m_semaphore = new SemaphoreSlim(1, 1);
+        readonly SemaphoreSlim m_semaphore;
         readonly Task<IDisposable> m_releaser;
 
-        public AsyncLock()
+        public static AsyncLock CreateLocked(out IDisposable releaser)
         {
+            var asyncLock = new AsyncLock(true);
+            releaser = asyncLock.m_releaser.Result;
+            return asyncLock;
+        }
+
+        AsyncLock(bool isLocked)
+        {
+            m_semaphore = new SemaphoreSlim(isLocked ? 0 : 1, 1);
             m_releaser = Task.FromResult((IDisposable)new Releaser(this));
         }
 

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -408,8 +408,8 @@ namespace ModernHttpClient
     class ByteArrayListStream : Stream
     {
         Exception exception;
-        IDisposable lockRelease = EmptyDisposable.Instance;
-        readonly AsyncLock readStreamLock = new AsyncLock();
+        IDisposable lockRelease;
+        readonly AsyncLock readStreamLock;
         readonly List<byte[]> bytes = new List<byte[]>();
 
         bool isCompleted;
@@ -420,7 +420,7 @@ namespace ModernHttpClient
         public ByteArrayListStream()
         {
             // Initially we have nothing to read so Reads should be parked
-            readStreamLock.LockAsync().ContinueWith(t => lockRelease = t.Result);
+            readStreamLock = AsyncLock.CreateLocked(out lockRelease);
         }
 
         public override bool CanRead { get { return true; } }


### PR DESCRIPTION
ByteArrayListStream asynchronously set the release object for its
AsyncLock after locking it in its constructor. However, if the
continuation doesn't run immediately, AddByteArray()/Complete() may
try to use the release object before it's set. When that happens the
lock never gets unlocked for ReadAsync().

Avoid the race condition by adding a method to create an AsyncLock that
starts out locked and returns the release object.