### PR TITLE
Usage of CancellationToken produces an SocketException

### DIFF
--- a/src/ModernHttpClient/ProgressStreamContent.cs
+++ b/src/ModernHttpClient/ProgressStreamContent.cs
@@ -94,6 +94,7 @@ namespace ModernHttpClient
             public ProgressStream(Stream stream, CancellationToken token)
             {
                 ParentStream = stream;
+                this.token = token;
 
                 ReadCallback = delegate { };
                 WriteCallback = delegate { };


### PR DESCRIPTION
Environment:
* Xamarin Android application
* Android phone 4.2.2
* Microsoft.Net.Http PCL 2.2.29
* ModernHttpClient 2.2.0

When I use an instance of HttpClient with NativeMessageHandler and try to cancel a download, using the CancellationToken an java.net.SocketException is thrown. If I run the same code with HttpClientHandler the code work as expected, throwing an OperationCanceledException.

I have created an demo app, who downloads a file using GetAsync, using both HttpClientHandler and NativeMessageHandler to demonstrate this issue.
	Link: https://www.dropbox.com/s/5n0ymyddsegxy1v/ModernHttpCancellationTokenError.zip?dl=0

Stacktrace:
```
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x00000] in <filename unknown>:0 
  at Android.Runtime.JNIEnv.CallIntMethod (IntPtr jobject, IntPtr jmethod, Android.Runtime.JValue[] parms) [0x00064] in /Users/builder/data/lanes/monodroid-mlion-monodroid-4.20-series/ba9bbbdd/source/monodroid/src/Mono.Android/src/Runtime/JNIEnv.g.cs:369 
  at Java.IO.InputStream.Read (System.Byte[] buffer, Int32 byteOffset, Int32 byteCount) [0x0004a] in /Users/builder/data/lanes/monodroid-mlion-monodroid-4.20-series/ba9bbbdd/source/monodroid/src/Mono.Android/platforms/android-21/src/generated/Java.IO.InputStream.cs:274 
  at Android.Runtime.InputStreamInvoker.Read (System.Byte[] buffer, Int32 offset, Int32 count) [0x00000] in /Users/builder/data/lanes/monodroid-mlion-monodroid-4.20-series/ba9bbbdd/source/monodroid/src/Mono.Android/src/Runtime/InputStreamInvoker.cs:30 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x00000] in <filename unknown>:0 
  at System.Runtime.CompilerServices.TaskAwaiter`1[System.Int32].GetResult () [0x00000] in <filename unknown>:0 
  at ModernHttpClient.ProgressStreamContent+ProgressStream+<ReadAsync>c__async0.MoveNext () [0x0004d] in /Users/paul/code/paulcbetts/modernhttpclient/src/ModernHttpClient/ProgressStreamContent.cs:166 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x00000] in <filename unknown>:0 
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable`1+ConfiguredTaskAwaiter[System.Int32].GetResult () [0x00000] in <filename unknown>:0 
  at System.IO.Stream+<CopyToAsync>c__async0.MoveNext () [0x00000] in <filename unknown>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x00000] in <filename unknown>:0 
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable+ConfiguredTaskAwaiter.GetResult () [0x00000] in <filename unknown>:0 
  at System.Net.Http.HttpContent+<LoadIntoBufferAsync>c__async1.MoveNext () [0x00000] in <filename unknown>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x00000] in <filename unknown>:0 
  at System.Runtime.CompilerServices.ConfiguredTaskAwaitable+ConfiguredTaskAwaiter.GetResult () [0x00000] in <filename unknown>:0 
  at System.Net.Http.HttpClient+<SendAsyncWorker>c__async0.MoveNext () [0x00000] in <filename unknown>:0 
--- End of stack trace from previous location where exception was thrown ---
  at System.Runtime.ExceptionServices.ExceptionDispatchInfo.Throw () [0x00000] in <filename unknown>:0 
  at System.Runtime.CompilerServices.TaskAwaiter`1[System.Net.Http.HttpResponseMessage].GetResult () [0x00000] in <filename unknown>:0 
  at ModernHttpCancellationTokenError.MainActivity+<StartDownload>c__async0.MoveNext () [0x000a1] in /Users/nicolascaorsi/Projects/ModernHttpCancellationTokenError/ModernHttpCancellationTokenError/MainActivity.cs:74 
  --- End of managed exception stack trace ---
java.net.SocketException: Socket closed
	at libcore.io.Posix.recvfromBytes(Native Method)
	at libcore.io.Posix.recvfrom(Posix.java:136)
	at libcore.io.BlockGuardOs.recvfrom(BlockGuardOs.java:164)
	at libcore.io.IoBridge.recvfrom(IoBridge.java:557)
	at java.net.PlainSocketImpl.read(PlainSocketImpl.java:490)
	at java.net.PlainSocketImpl.access$000(PlainSocketImpl.java:46)
	at java.net.PlainSocketImpl$PlainSocketInputStream.read(PlainSocketImpl.java:240)
	at okio.Okio$2.read(Okio.java:136)
	at okio.AsyncTimeout$2.read(AsyncTimeout.java:211)
	at okio.RealBufferedSource.read(RealBufferedSource.java:50)
	at com.squareup.okhttp.internal.http.HttpConnection$FixedLengthSource.read(HttpConnection.java:457)
	at okio.RealBufferedSource$1.read(RealBufferedSource.java:227)
	at dalvik.system.NativeStart.run(Native Method)```