### PR TITLE
Cert pinning (and fix nachocove/qa#156)

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "vendor/okhttp"]
 	path = vendor/okhttp
-	url = https://github.com/paulcbetts/OkHttp-Xamarin.git
+	url = https://github.com/nachocove/OkHttp-Xamarin.git

--- a/Makefile
+++ b/Makefile
@@ -38,5 +38,5 @@ ModernHttpClient.Portable.dll:
 
 clean:
 	$(MDTOOL) build -t:Clean ModernHttpClient.sln
-	rm *.dll
+	rm -f *.dll
 	rm -rf build

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -170,8 +170,9 @@ namespace ModernHttpClient
                         ret.Headers.TryAddWithoutValidation(v.Key.ToString(), v.Value.ToString());
                         ret.Content.Headers.TryAddWithoutValidation(v.Key.ToString(), v.Value.ToString());
                     }
-
-                    data.FutureResponse.TrySetResult(ret);
+                    // NB: The awaiting code can synchronously call read, which will block, and we'll
+                    // never get a didReceiveData, because we have not returned from DidReceiveResponse.
+                    Task.Run (() => { data.FutureResponse.TrySetResult(ret); });
                 } catch (Exception ex) {
                     data.FutureResponse.TrySetException(ex);
                 }

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -345,7 +345,10 @@ namespace ModernHttpClient
             string AuthenticationTypeFromAuthenticationMethod (string method)
             {
                 if (NSUrlProtectionSpace.AuthenticationMethodDefault == method ||
-                    NSUrlProtectionSpace.AuthenticationMethodHTTPBasic == method) {
+                    NSUrlProtectionSpace.AuthenticationMethodHTTPBasic == method ||
+                    NSUrlProtectionSpace.AuthenticationMethodNTLM == method ||
+                    NSUrlProtectionSpace.AuthenticationMethodHTTPDigest == method) {
+                    // Use Basic as a way to get the user+pass cred out.
                     return "Basic";
                 } else {
                     return null;

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -298,7 +298,11 @@ namespace ModernHttpClient
                 }
 
             sslErrorVerify:
-                bool result = ServicePointManager.ServerCertificateValidationCallback(this, root, chain, errors);
+                // NachoCove: Add this to make it look like other HTTP client
+                var url = task.CurrentRequest.Url.ToString ();
+                var request = new HttpWebRequest (new Uri (url));
+                // End of NachoCove
+                bool result = ServicePointManager.ServerCertificateValidationCallback(request, root, chain, errors);
                 if (result) {
                     completionHandler(
                         NSUrlSessionAuthChallengeDisposition.UseCredential,

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -315,7 +315,7 @@ namespace ModernHttpClient
             Uri UriFromNSUrlProtectionSpace (NSUrlProtectionSpace pSpace)
             {
                 var builder = new UriBuilder(pSpace.Protocol, pSpace.Host);
-                builder.Port = pSpace.Port;
+                builder.Port = (int)pSpace.Port;
                 Uri retval;
                 try {
                     retval = builder.Uri;

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -107,7 +107,10 @@ namespace ModernHttpClient
             cancellationToken.ThrowIfCancellationRequested();
 
             var ret = new TaskCompletionSource<HttpResponseMessage>();
-            cancellationToken.Register(() => ret.TrySetCanceled());
+            cancellationToken.Register(() => {
+                op.Cancel();
+                ret.TrySetCanceled();
+            });
 
             lock (inflightRequests) {
                 inflightRequests[op] = new InflightOperation() {

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -46,8 +46,11 @@ namespace ModernHttpClient
         public NativeMessageHandler(): this(false, false) { }
         public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification)
         {
+            var config = NSUrlSessionConfiguration.EphemeralSessionConfiguration;
+            config.TimeoutIntervalForRequest = 1000;
+            config.TimeoutIntervalForResource = 1000;
             session = NSUrlSession.FromConfiguration(
-                NSUrlSessionConfiguration.DefaultSessionConfiguration, 
+                config, 
                 new DataTaskDelegate(this), null);
 
             this.throwOnCaptiveNetwork = throwOnCaptiveNetwork;

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -128,6 +128,15 @@ namespace ModernHttpClient
                 this.This = that;
             }
 
+            public override void WillPerformHttpRedirection(NSUrlSession session, NSUrlSessionTask task, NSHttpUrlResponse response, NSUrlRequest newRequest, Action<NSUrlRequest> completionHandler)
+            {
+                if (this.This.AllowAutoRedirect) {
+                    completionHandler(newRequest);
+                } else {
+                    completionHandler(null);
+                }
+            }
+
             public override void DidReceiveResponse(NSUrlSession session, NSUrlSessionDataTask dataTask, NSUrlResponse response, Action<NSUrlSessionResponseDisposition> completionHandler)
             {
                 var data = getResponseForTask(dataTask);


### PR DESCRIPTION
- Make the check cert callback to return a HttpWebRequest instead of DataTaskDelegate.
- The crash in qa#156 occurs because AS SM changes the the callback pointer to ServerCertificatePeek method which tries to cast a DataTaskDelegate into a HttpWebRequest.
- This fixes the crash and is needed for supporting cert pinning.