### PR TITLE
Handle errors from the kCFErrorDomainCFNetwork error domain and always r...

### DIFF
--- a/src/ModernHttpClient/ModernHttpClient.iOS.csproj
+++ b/src/ModernHttpClient/ModernHttpClient.iOS.csproj
@@ -60,6 +60,8 @@
     <Compile Include="ProgressStreamContent.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="iOS\NativeCookieHandler.cs" />
+    <Compile Include="iOS\CFNetworkErrors.cs" />
+    <Compile Include="iOS\NSErrorExtended.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/ModernHttpClient/ModernHttpClient.iOS64.csproj
+++ b/src/ModernHttpClient/ModernHttpClient.iOS64.csproj
@@ -48,6 +48,8 @@
     <Compile Include="ProgressStreamContent.cs" />
     <Compile Include="Utility.cs" />
     <Compile Include="iOS\NativeCookieHandler.cs" />
+    <Compile Include="iOS\CFNetworkErrors.cs" />
+    <Compile Include="iOS\NSErrorExtended.cs" />
   </ItemGroup>
   <ItemGroup>
     <Folder Include="Properties\" />

--- a/src/ModernHttpClient/iOS/CFNetworkErrors.cs
+++ b/src/ModernHttpClient/iOS/CFNetworkErrors.cs
@@ -1,0 +1,124 @@
+﻿#if UNIFIED
+using Foundation;
+#else
+using MonoTouch.Foundation;
+using System.Globalization;
+#endif
+
+// These definitions are not currently provided by Xamarin.
+// To avoid a potential conflict, these are in a namespace specific to this library.
+
+namespace ModernHttpClient.CoreFoundation
+{
+    public static class CFNetworkError
+    {
+        public static NSString ErrorDomain { get { return new NSString("kCFErrorDomainCFNetwork"); } }
+    }
+
+    // From Apple reference docs:
+    // https://developer.apple.com/library/ios/documentation/Networking/Reference/CFNetworkErrors/#//apple_ref/c/tdef/CFNetworkErrors
+    public enum CFNetworkErrors
+    {
+        CFHostErrorHostNotFound = 1,
+        CFHostErrorUnknown = 2,
+
+        // SOCKS errors
+        CFSOCKSErrorUnknownClientVersion = 100,
+        CFSOCKSErrorUnsupportedServerVersion = 101,
+
+        // SOCKS4-specific errors
+        CFSOCKS4ErrorRequestFailed  = 110,
+        CFSOCKS4ErrorIdentdFailed = 111,
+        CFSOCKS4ErrorIdConflict = 112,
+        CFSOCKS4ErrorUnknownStatusCode = 113,
+
+        // SOCKS5-specific errors
+        CFSOCKS5ErrorBadState = 120,
+        CFSOCKS5ErrorBadResponseAddr = 121,
+        CFSOCKS5ErrorBadCredentials = 122,
+        CFSOCKS5ErrorUnsupportedNegotiationMethod = 123,
+        CFSOCKS5ErrorNoAcceptableMethod = 124,
+
+        // FTP errors
+        CFFTPErrorUnexpectedStatusCode = 200,
+
+        // HTTP errors
+        CFErrorHttpAuthenticationTypeUnsupported = 300,
+        CFErrorHttpBadCredentials = 301,
+        CFErrorHttpConnectionLost = 302,
+        CFErrorHttpParseFailure = 303,
+        CFErrorHttpRedirectionLoopDetected = 304,
+        CFErrorHttpBadURL = 305,
+        CFErrorHttpProxyConnectionFailure = 306,
+        CFErrorHttpBadProxyCredentials = 307,
+        CFErrorPACFileError = 308,
+        CFErrorPACFileAuth = 309,
+        CFErrorHttpsProxyConnectionFailure = 310,
+        CFStreamErrorHttpsProxyFailureUnexpectedResponseToConnectMethod = 311,
+
+        // CFURL and CFURLConnection Errors
+        CFURLErrorUnknown = -998,
+        CFURLErrorCancelled = -999,
+        CFURLErrorBadURL = -1000,
+        CFURLErrorTimedOut = -1001,
+        CFURLErrorUnsupportedURL = -1002,
+        CFURLErrorCannotFindHost = -1003,
+        CFURLErrorCannotConnectToHost = -1004,
+        CFURLErrorNetworkConnectionLost = -1005,
+        CFURLErrorDNSLookupFailed = -1006,
+        CFURLErrorHTTPTooManyRedirects = -1007,
+        CFURLErrorResourceUnavailable = -1008,
+        CFURLErrorNotConnectedToInternet = -1009,
+        CFURLErrorRedirectToNonExistentLocation = -1010,
+        CFURLErrorBadServerResponse = -1011,
+        CFURLErrorUserCancelledAuthentication = -1012,
+        CFURLErrorUserAuthenticationRequired = -1013,
+        CFURLErrorZeroByteResource = -1014,
+        CFURLErrorCannotDecodeRawData = -1015,
+        CFURLErrorCannotDecodeContentData = -1016,
+        CFURLErrorCannotParseResponse = -1017,
+        CFURLErrorInternationalRoamingOff = -1018,
+        CFURLErrorCallIsActive = -1019,
+        CFURLErrorDataNotAllowed = -1020,
+        CFURLErrorRequestBodyStreamExhausted = -1021,
+        CFURLErrorFileDoesNotExist = -1100,
+        CFURLErrorFileIsDirectory = -1101,
+        CFURLErrorNoPermissionsToReadFile = -1102,
+        CFURLErrorDataLengthExceedsMaximum = -1103,
+
+        // SSL errors
+        CFURLErrorSecureConnectionFailed = -1200,
+        CFURLErrorServerCertificateHasBadDate = -1201,
+        CFURLErrorServerCertificateUntrusted = -1202,
+        CFURLErrorServerCertificateHasUnknownRoot = -1203,
+        CFURLErrorServerCertificateNotYetValid = -1204,
+        CFURLErrorClientCertificateRejected = -1205,
+        CFURLErrorClientCertificateRequired = -1206,
+
+        CFURLErrorCannotLoadFromNetwork = -2000,
+
+        // Download and file I/O errors
+        CFURLErrorCannotCreateFile = -3000,
+        CFURLErrorCannotOpenFile = -3001,
+        CFURLErrorCannotCloseFile = -3002,
+        CFURLErrorCannotWriteToFile = -3003,
+        CFURLErrorCannotRemoveFile = -3004,
+        CFURLErrorCannotMoveFile = -3005,
+        CFURLErrorDownloadDecodingFailedMidStream = -3006,
+        CFURLErrorDownloadDecodingFailedToComplete = -3007,
+
+        // Cookie errors
+        CFHTTPCookieCannotParseCookieFile = -4000,
+
+        // Errors originating from CFNetServices
+        CFNetServiceErrorUnknown = -72000,
+        CFNetServiceErrorCollision = -72001,
+        CFNetServiceErrorNotFound = -72002,
+        CFNetServiceErrorInProgress = -72003,
+        CFNetServiceErrorBadArgument = -72004,
+        CFNetServiceErrorCancel = -72005,
+        CFNetServiceErrorInvalid = -72006,
+        CFNetServiceErrorTimeout = -72007,
+        CFNetServiceErrorDNSServiceFailure = -73000,
+    }
+}

--- a/src/ModernHttpClient/iOS/NSErrorExtended.cs
+++ b/src/ModernHttpClient/iOS/NSErrorExtended.cs
@@ -1,0 +1,67 @@
+﻿// The NSUrlError enum provided by Xamarin is missing some values.  
+// To avoid a potential conflict, these are in a namespace specific to this library.
+
+namespace ModernHttpClient.Foundation
+{
+    public enum NSUrlErrorExtended
+    {
+        Unknown = -1,
+        Cancelled = -999,
+        BadURL = -1000,
+        TimedOut = -1001,
+        UnsupportedURL = -1002,
+        CannotFindHost = -1003,
+        CannotConnectToHost = -1004,
+        NetworkConnectionLost = -1005,
+        DNSLookupFailed = -1006,
+        HTTPTooManyRedirects = -1007,
+        ResourceUnavailable = -1008,
+        NotConnectedToInternet = -1009,
+        RedirectToNonExistentLocation = -1010,
+        BadServerResponse = -1011,
+        UserCancelledAuthentication = -1012,
+        UserAuthenticationRequired = -1013,
+        ZeroByteResource = -1014,
+        CannotDecodeRawData = -1015,
+        CannotDecodeContentData = -1016,
+        CannotParseResponse = -1017,
+
+        // NEW
+        InternationalRoamingOff = -1018,
+        CallIsActive = -1019,
+        DataNotAllowed = -1020,
+        RequestBodyStreamExhausted = -1021,
+
+        // SSL errors
+        SecureConnectionFailed = -1200,
+        ServerCertificateHasBadDate = -1201,
+        ServerCertificateUntrusted = -1202,
+        ServerCertificateHasUnknownRoot = -1203,
+        ServerCertificateNotYetValid = -1204,
+        ClientCertificateRejected = -1205,
+
+        // NEW
+        ClientCertificateRequired = -1206,
+
+        CannotLoadFromNetwork = -2000,
+
+        // Downoad and file I/O errors
+        CannotCreateFile = -3000,
+        CannotOpenFile = -3001,
+        CannotCloseFile = -3002,
+        CannotWriteToFile = -3003,
+        CannotRemoveFile = -3004,
+        CannotMoveFile = -3005,
+        DownloadDecodingFailedMidStream = -3006,
+        DownloadDecodingFailedToComplete = -3007,
+
+        FileDoesNotExist = -1100,
+        FileIsDirectory = -1101,
+        NoPermissionsToReadFile = -1102,
+        DataLengthExceedsMaximum = -1103,
+
+        BackgroundSessionRequiresSharedContainer = -995,
+        BackgroundSessionInUseByAnotherProcess = -996,
+        BackgroundSessionWasDisconnected = -997
+    }
+}

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -6,10 +6,11 @@ using System.Collections.Generic;
 using System.IO;
 using System.Linq;
 using System.Net;
-using System.Net.Cache;
 using System.Net.Security;
 using System.Security.Cryptography.X509Certificates;
 using System.Text.RegularExpressions;
+using ModernHttpClient.CoreFoundation;
+using ModernHttpClient.Foundation;
 
 #if UNIFIED
 using Foundation;
@@ -322,98 +323,216 @@ namespace ModernHttpClient
                 completionHandler(nextRequest);
             }
 
-            Exception createExceptionForNSError(NSError error)
+            static Exception createExceptionForNSError(NSError error)
             {
                 var ret = default(Exception);
-                var urlError = default(NSUrlError);
                 var webExceptionStatus = WebExceptionStatus.UnknownError;
 
-                // If the domain is something other than NSUrlErrorDomain, 
-                // just grab the default info
-                if (error.Domain != NSError.NSUrlErrorDomain) goto leave;
+                var innerException = new NSErrorException(error);
 
-                // Convert the error code into an enumeration (this is future
-                // proof, rather than just casting integer)
-                if (!Enum.TryParse<NSUrlError>(error.Code.ToString(), out urlError)) urlError = NSUrlError.Unknown;
+                if (error.Domain == NSError.NSUrlErrorDomain) {
+                    // Convert the error code into an enumeration (this is future
+                    // proof, rather than just casting integer)
+                    NSUrlErrorExtended urlError;
+                    if (!Enum.TryParse<NSUrlErrorExtended>(error.Code.ToString(), out urlError)) urlError = NSUrlErrorExtended.Unknown;
 
-                // Parse the enum into a web exception status or exception. some
-                // of these values don't necessarily translate completely to
-                // what WebExceptionStatus supports, so made some best guesses
-                // here.  for your reading pleasure, compare these:
-                //
-                // Apple docs: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Constants/Reference/reference.html
-                // .NET docs: http://msdn.microsoft.com/en-us/library/system.net.webexceptionstatus(v=vs.110).aspx
-                switch(urlError) {
-                case NSUrlError.Cancelled:
-                case NSUrlError.UserCancelledAuthentication:
-                    ret = new OperationCanceledException();
-                    break;
-                case NSUrlError.BadURL:
-                case NSUrlError.UnsupportedURL:
-                case NSUrlError.CannotConnectToHost:
-                case NSUrlError.ResourceUnavailable:
-                case NSUrlError.NotConnectedToInternet:
-                case NSUrlError.UserAuthenticationRequired:
-                    webExceptionStatus = WebExceptionStatus.ConnectFailure;
-                    break;
-                case NSUrlError.TimedOut:
-                    webExceptionStatus = WebExceptionStatus.Timeout;
-                    break;
-                case NSUrlError.CannotFindHost:
-                case NSUrlError.DNSLookupFailed:
-                    webExceptionStatus = WebExceptionStatus.NameResolutionFailure;
-                    break;
-                case NSUrlError.DataLengthExceedsMaximum:
-                    webExceptionStatus = WebExceptionStatus.MessageLengthLimitExceeded;
-                    break;
-                case NSUrlError.NetworkConnectionLost:
-                    webExceptionStatus = WebExceptionStatus.ConnectionClosed;
-                    break;
-                case NSUrlError.HTTPTooManyRedirects:
-                case NSUrlError.RedirectToNonExistentLocation:
-                    webExceptionStatus = WebExceptionStatus.ProtocolError;
-                    break;
-                case NSUrlError.BadServerResponse:
-                case NSUrlError.ZeroByteResource:
-                case NSUrlError.CannotDecodeContentData:
-                case NSUrlError.CannotDecodeRawData:
-                case NSUrlError.CannotParseResponse:
-                case NSUrlError.FileDoesNotExist:
-                case NSUrlError.FileIsDirectory:
-                case NSUrlError.NoPermissionsToReadFile:
-                case NSUrlError.CannotLoadFromNetwork:
-                case NSUrlError.CannotCreateFile:
-                case NSUrlError.CannotOpenFile:
-                case NSUrlError.CannotCloseFile:
-                case NSUrlError.CannotWriteToFile:
-                case NSUrlError.CannotRemoveFile:
-                case NSUrlError.CannotMoveFile:
-                case NSUrlError.DownloadDecodingFailedMidStream:
-                case NSUrlError.DownloadDecodingFailedToComplete:
-                    webExceptionStatus = WebExceptionStatus.ReceiveFailure;
-                    break;
-                case NSUrlError.SecureConnectionFailed:
-                    webExceptionStatus = WebExceptionStatus.SecureChannelFailure;
-                    break;
-                case NSUrlError.ServerCertificateHasBadDate:
-                case NSUrlError.ServerCertificateHasUnknownRoot:
-                case NSUrlError.ServerCertificateNotYetValid:
-                case NSUrlError.ServerCertificateUntrusted:
-                case NSUrlError.ClientCertificateRejected:
-                    webExceptionStatus = WebExceptionStatus.TrustFailure;
-                    break;
+                    // Parse the enum into a web exception status or exception. Some
+                    // of these values don't necessarily translate completely to
+                    // what WebExceptionStatus supports, so made some best guesses
+                    // here.  For your reading pleasure, compare these:
+                    //
+                    // Apple docs: https://developer.apple.com/library/mac/documentation/Cocoa/Reference/Foundation/Miscellaneous/Foundation_Constants/index.html#//apple_ref/doc/constant_group/URL_Loading_System_Error_Codes
+                    // .NET docs: http://msdn.microsoft.com/en-us/library/system.net.webexceptionstatus(v=vs.110).aspx
+                    switch (urlError) {
+                        case NSUrlErrorExtended.Cancelled:
+                        case NSUrlErrorExtended.UserCancelledAuthentication:
+                            // No more processing is required so just return.
+                            ret = new OperationCanceledException(error.LocalizedDescription, innerException);
+                            return ret;
+                        case NSUrlErrorExtended.BadURL:
+                        case NSUrlErrorExtended.UnsupportedURL:
+                        case NSUrlErrorExtended.CannotConnectToHost:
+                        case NSUrlErrorExtended.ResourceUnavailable:
+                        case NSUrlErrorExtended.NotConnectedToInternet:
+                        case NSUrlErrorExtended.UserAuthenticationRequired:
+                        case NSUrlErrorExtended.InternationalRoamingOff:
+                        case NSUrlErrorExtended.CallIsActive:
+                        case NSUrlErrorExtended.DataNotAllowed:
+                            webExceptionStatus = WebExceptionStatus.ConnectFailure;
+                            break;
+                        case NSUrlErrorExtended.TimedOut:
+                            webExceptionStatus = WebExceptionStatus.Timeout;
+                            break;
+                        case NSUrlErrorExtended.CannotFindHost:
+                        case NSUrlErrorExtended.DNSLookupFailed:
+                            webExceptionStatus = WebExceptionStatus.NameResolutionFailure;
+                            break;
+                        case NSUrlErrorExtended.DataLengthExceedsMaximum:
+                            webExceptionStatus = WebExceptionStatus.MessageLengthLimitExceeded;
+                            break;
+                        case NSUrlErrorExtended.NetworkConnectionLost:
+                            webExceptionStatus = WebExceptionStatus.ConnectionClosed;
+                            break;
+                        case NSUrlErrorExtended.HTTPTooManyRedirects:
+                        case NSUrlErrorExtended.RedirectToNonExistentLocation:
+                            webExceptionStatus = WebExceptionStatus.ProtocolError;
+                            break;
+                        case NSUrlErrorExtended.RequestBodyStreamExhausted:
+                            webExceptionStatus = WebExceptionStatus.SendFailure;
+                            break;
+                        case NSUrlErrorExtended.BadServerResponse:
+                        case NSUrlErrorExtended.ZeroByteResource:
+                        case NSUrlErrorExtended.CannotDecodeRawData:
+                        case NSUrlErrorExtended.CannotDecodeContentData:
+                        case NSUrlErrorExtended.CannotParseResponse:
+                        case NSUrlErrorExtended.FileDoesNotExist:
+                        case NSUrlErrorExtended.FileIsDirectory:
+                        case NSUrlErrorExtended.NoPermissionsToReadFile:
+                        case NSUrlErrorExtended.CannotLoadFromNetwork:
+                        case NSUrlErrorExtended.CannotCreateFile:
+                        case NSUrlErrorExtended.CannotOpenFile:
+                        case NSUrlErrorExtended.CannotCloseFile:
+                        case NSUrlErrorExtended.CannotWriteToFile:
+                        case NSUrlErrorExtended.CannotRemoveFile:
+                        case NSUrlErrorExtended.CannotMoveFile:
+                        case NSUrlErrorExtended.DownloadDecodingFailedMidStream:
+                        case NSUrlErrorExtended.DownloadDecodingFailedToComplete:
+                            webExceptionStatus = WebExceptionStatus.ReceiveFailure;
+                            break;
+                        case NSUrlErrorExtended.SecureConnectionFailed:
+                            webExceptionStatus = WebExceptionStatus.SecureChannelFailure;
+                            break;
+                        case NSUrlErrorExtended.ServerCertificateHasBadDate:
+                        case NSUrlErrorExtended.ServerCertificateHasUnknownRoot:
+                        case NSUrlErrorExtended.ServerCertificateNotYetValid:
+                        case NSUrlErrorExtended.ServerCertificateUntrusted:
+                        case NSUrlErrorExtended.ClientCertificateRejected:
+                        case NSUrlErrorExtended.ClientCertificateRequired:
+                            webExceptionStatus = WebExceptionStatus.TrustFailure;
+                            break;
+                    }
+                } else if (error.Domain == CFNetworkError.ErrorDomain) {
+                    // Convert the error code into an enumeration (this is future
+                    // proof, rather than just casting integer)
+                    CFNetworkErrors networkError;
+                    if (!Enum.TryParse<CFNetworkErrors>(error.Code.ToString(), out networkError)) networkError = CFNetworkErrors.CFHostErrorUnknown;
+
+                    // Parse the enum into a web exception status or exception. Some
+                    // of these values don't necessarily translate completely to
+                    // what WebExceptionStatus supports, so made some best guesses
+                    // here.  For your reading pleasure, compare these:
+                    //
+                    // Apple docs: https://developer.apple.com/library/ios/documentation/Networking/Reference/CFNetworkErrors/#//apple_ref/c/tdef/CFNetworkErrors
+                    // .NET docs: http://msdn.microsoft.com/en-us/library/system.net.webexceptionstatus(v=vs.110).aspx
+                    switch (networkError) {
+                        case CFNetworkErrors.CFURLErrorCancelled:
+                        case CFNetworkErrors.CFURLErrorUserCancelledAuthentication:
+                        case CFNetworkErrors.CFNetServiceErrorCancel:
+                            // No more processing is required so just return.
+                            ret = new OperationCanceledException(error.LocalizedDescription, innerException);
+                            return ret;
+                        case CFNetworkErrors.CFSOCKS5ErrorBadCredentials:
+                        case CFNetworkErrors.CFSOCKS5ErrorUnsupportedNegotiationMethod:
+                        case CFNetworkErrors.CFSOCKS5ErrorNoAcceptableMethod:
+                        case CFNetworkErrors.CFErrorHttpAuthenticationTypeUnsupported:
+                        case CFNetworkErrors.CFErrorHttpBadCredentials:
+                        case CFNetworkErrors.CFErrorHttpBadURL:
+                        case CFNetworkErrors.CFURLErrorBadURL:
+                        case CFNetworkErrors.CFURLErrorUnsupportedURL:
+                        case CFNetworkErrors.CFURLErrorCannotConnectToHost:
+                        case CFNetworkErrors.CFURLErrorResourceUnavailable:
+                        case CFNetworkErrors.CFURLErrorNotConnectedToInternet:
+                        case CFNetworkErrors.CFURLErrorUserAuthenticationRequired:
+                        case CFNetworkErrors.CFURLErrorInternationalRoamingOff:
+                        case CFNetworkErrors.CFURLErrorCallIsActive:
+                        case CFNetworkErrors.CFURLErrorDataNotAllowed:
+                            webExceptionStatus = WebExceptionStatus.ConnectFailure;
+                            break;
+                        case CFNetworkErrors.CFURLErrorTimedOut:
+                        case CFNetworkErrors.CFNetServiceErrorTimeout:
+                            webExceptionStatus = WebExceptionStatus.Timeout;
+                            break;
+                        case CFNetworkErrors.CFHostErrorHostNotFound:
+                        case CFNetworkErrors.CFURLErrorCannotFindHost:
+                        case CFNetworkErrors.CFURLErrorDNSLookupFailed:
+                        case CFNetworkErrors.CFNetServiceErrorDNSServiceFailure:
+                            webExceptionStatus = WebExceptionStatus.NameResolutionFailure;
+                            break;
+                        case CFNetworkErrors.CFURLErrorDataLengthExceedsMaximum:
+                            webExceptionStatus = WebExceptionStatus.MessageLengthLimitExceeded;
+                            break;
+                        case CFNetworkErrors.CFErrorHttpConnectionLost:
+                        case CFNetworkErrors.CFURLErrorNetworkConnectionLost:
+                            webExceptionStatus = WebExceptionStatus.ConnectionClosed;
+                            break;
+                        case CFNetworkErrors.CFErrorHttpRedirectionLoopDetected:
+                        case CFNetworkErrors.CFURLErrorHTTPTooManyRedirects:
+                        case CFNetworkErrors.CFURLErrorRedirectToNonExistentLocation:
+                            webExceptionStatus = WebExceptionStatus.ProtocolError;
+                            break;
+                        case CFNetworkErrors.CFSOCKSErrorUnknownClientVersion:
+                        case CFNetworkErrors.CFSOCKSErrorUnsupportedServerVersion:
+                        case CFNetworkErrors.CFErrorHttpParseFailure:
+                        case CFNetworkErrors.CFURLErrorRequestBodyStreamExhausted:
+                            webExceptionStatus = WebExceptionStatus.SendFailure;
+                            break;
+                        case CFNetworkErrors.CFSOCKS4ErrorRequestFailed:
+                        case CFNetworkErrors.CFSOCKS4ErrorIdentdFailed:
+                        case CFNetworkErrors.CFSOCKS4ErrorIdConflict:
+                        case CFNetworkErrors.CFSOCKS4ErrorUnknownStatusCode:
+                        case CFNetworkErrors.CFSOCKS5ErrorBadState:
+                        case CFNetworkErrors.CFSOCKS5ErrorBadResponseAddr:
+                        case CFNetworkErrors.CFURLErrorBadServerResponse:
+                        case CFNetworkErrors.CFURLErrorZeroByteResource:
+                        case CFNetworkErrors.CFURLErrorCannotDecodeRawData:
+                        case CFNetworkErrors.CFURLErrorCannotDecodeContentData:
+                        case CFNetworkErrors.CFURLErrorCannotParseResponse:
+                        case CFNetworkErrors.CFURLErrorFileDoesNotExist:
+                        case CFNetworkErrors.CFURLErrorFileIsDirectory:
+                        case CFNetworkErrors.CFURLErrorNoPermissionsToReadFile:
+                        case CFNetworkErrors.CFURLErrorCannotLoadFromNetwork:
+                        case CFNetworkErrors.CFURLErrorCannotCreateFile:
+                        case CFNetworkErrors.CFURLErrorCannotOpenFile:
+                        case CFNetworkErrors.CFURLErrorCannotCloseFile:
+                        case CFNetworkErrors.CFURLErrorCannotWriteToFile:
+                        case CFNetworkErrors.CFURLErrorCannotRemoveFile:
+                        case CFNetworkErrors.CFURLErrorCannotMoveFile:
+                        case CFNetworkErrors.CFURLErrorDownloadDecodingFailedMidStream:
+                        case CFNetworkErrors.CFURLErrorDownloadDecodingFailedToComplete:
+                        case CFNetworkErrors.CFHTTPCookieCannotParseCookieFile:
+                        case CFNetworkErrors.CFNetServiceErrorUnknown:
+                        case CFNetworkErrors.CFNetServiceErrorCollision:
+                        case CFNetworkErrors.CFNetServiceErrorNotFound:
+                        case CFNetworkErrors.CFNetServiceErrorInProgress:
+                        case CFNetworkErrors.CFNetServiceErrorBadArgument:
+                        case CFNetworkErrors.CFNetServiceErrorInvalid:
+                            webExceptionStatus = WebExceptionStatus.ReceiveFailure;
+                            break;
+                        case CFNetworkErrors.CFURLErrorServerCertificateHasBadDate:
+                        case CFNetworkErrors.CFURLErrorServerCertificateUntrusted:
+                        case CFNetworkErrors.CFURLErrorServerCertificateHasUnknownRoot:
+                        case CFNetworkErrors.CFURLErrorServerCertificateNotYetValid:
+                        case CFNetworkErrors.CFURLErrorClientCertificateRejected:
+                        case CFNetworkErrors.CFURLErrorClientCertificateRequired:
+                            webExceptionStatus = WebExceptionStatus.TrustFailure;
+                            break;
+                        case CFNetworkErrors.CFURLErrorSecureConnectionFailed:
+                            webExceptionStatus = WebExceptionStatus.SecureChannelFailure;
+                            break;
+                        case CFNetworkErrors.CFErrorHttpProxyConnectionFailure:
+                        case CFNetworkErrors.CFErrorHttpBadProxyCredentials:
+                        case CFNetworkErrors.CFErrorPACFileError:
+                        case CFNetworkErrors.CFErrorPACFileAuth:
+                        case CFNetworkErrors.CFErrorHttpsProxyConnectionFailure:
+                        case CFNetworkErrors.CFStreamErrorHttpsProxyFailureUnexpectedResponseToConnectMethod:
+                            webExceptionStatus = WebExceptionStatus.RequestProhibitedByProxy;
+                            break;
+                    }
                 }
 
-                // If we parsed a web exception status code, create an exception
-                // for it
-                if (webExceptionStatus != WebExceptionStatus.UnknownError) {
-                    ret = new WebException(error.LocalizedDescription, webExceptionStatus);
-                }
-
-            leave:
-                // If no exception generated yet, throw a normal exception with
-                // the error message.
-                return ret ?? new Exception(error.LocalizedDescription);
+                // Always create a WebException so that it can be handled by the client.
+                ret = new WebException(error.LocalizedDescription, innerException, webExceptionStatus, response: null);
+                return ret;
             }
         }
     }

--- a/src/Playground.Android/Resources/Resource.designer.cs
+++ b/src/Playground.Android/Resources/Resource.designer.cs
@@ -108,14 +108,14 @@ namespace Playground.Android
 		public partial class String
 		{
 			
+			// aapt resource value: 0x7f040002
+			public const int app_name = 2130968578;
+			
 			// aapt resource value: 0x7f040001
-			public const int app_name = 2130968577;
+			public const int hello = 2130968577;
 			
 			// aapt resource value: 0x7f040000
-			public const int hello = 2130968576;
-			
-			// aapt resource value: 0x7f040002
-			public const int library_name = 2130968578;
+			public const int library_name = 2130968576;
 			
 			static String()
 			{


### PR DESCRIPTION
...eturn a WebException

- Add CFNetworkErrors enum missing from Xamarin package.
- Add NSUrlErrorExtended enum with values missing from Xamarin package.
- Include an NSErrorException as the inner exception so that the client of the library can troubleshoot issues.
- Always generate a WebExeption from the NSError - even if the status is unknown - so that it can be caught by the client.