### PR TITLE
Pass the hostname instead of delegate/verifier as the sender to the S…

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -302,7 +302,8 @@ namespace ModernHttpClient
                 }
 
             sslErrorVerify:
-                bool result = ServicePointManager.ServerCertificateValidationCallback(this, root, chain, errors);
+                var hostname = task.CurrentRequest.Url.AbsoluteString;
+                bool result = ServicePointManager.ServerCertificateValidationCallback(hostname, root, chain, errors);
                 if (result) {
                     completionHandler(
                         NSUrlSessionAuthChallengeDisposition.UseCredential,


### PR DESCRIPTION
…erverCertificateValidatorCallback so that the client has information about what server returned the certificate which can be used in validation and when alerting the user.