### PR TITLE
Pass the hostname to the certificate validator, not the absolute URL …

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -302,7 +302,7 @@ namespace ModernHttpClient
                 }
 
             sslErrorVerify:
-                var hostname = task.CurrentRequest.Url.AbsoluteString;
+                var hostname = task.CurrentRequest.Url.Host;
                 bool result = ServicePointManager.ServerCertificateValidationCallback(hostname, root, chain, errors);
                 if (result) {
                     completionHandler(


### PR DESCRIPTION
…string, for consistency with the Android implementation.