### PR TITLE
Fix for lost HttpHeader items

### DIFF
--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -152,8 +152,10 @@ namespace ModernHttpClient
 
             var respHeaders = resp.Headers();
             foreach (var k in respHeaders.Names()) {
-                ret.Headers.TryAddWithoutValidation(k, respHeaders.Get(k));
-                ret.Content.Headers.TryAddWithoutValidation(k, respHeaders.Get(k));
+				foreach (string item in respHeaders.Values(k)) {
+					ret.Headers.TryAddWithoutValidation(k, item);
+					ret.Content.Headers.TryAddWithoutValidation(k, item);
+				}               
             }
 
             return ret;


### PR DESCRIPTION
In cases where there are multiple header entries with the same name,
only the first one in the collection was being copied from the OkHttp
Header to the HttpResponseMessage.Headers collection