### PR TITLE
Adding NTLM authentication for iOS.

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -244,6 +244,24 @@ namespace ModernHttpClient
 
             public override void DidReceiveChallenge(NSUrlSession session, NSUrlSessionTask task, NSUrlAuthenticationChallenge challenge, Action<NSUrlSessionAuthChallengeDisposition, NSUrlCredential> completionHandler)
             {
+               
+
+                if (challenge.ProtectionSpace.AuthenticationMethod == NSUrlProtectionSpace.AuthenticationMethodNTLM) {
+                    NetworkCredential credentialsToUse;
+
+                    if (This.Credentials != null) {
+                        if (This.Credentials is NetworkCredential) {
+                            credentialsToUse = (NetworkCredential)This.Credentials;
+                        } else {
+                            var uri = this.getResponseForTask(task).Request.RequestUri;
+                            credentialsToUse = This.Credentials.GetCredential(uri, "NTLM");
+                        }
+                        var credential = new NSUrlCredential(credentialsToUse.UserName, credentialsToUse.Password, NSUrlCredentialPersistence.ForSession);
+                        completionHandler(NSUrlSessionAuthChallengeDisposition.UseCredential, credential);
+                    }
+                    return;
+                }
+
                 if (!This.customSSLVerification) {
                     goto doDefault;
                 }

--- a/src/Playground.Android/Resources/Resource.designer.cs
+++ b/src/Playground.Android/Resources/Resource.designer.cs
@@ -48,6 +48,9 @@ namespace Playground.Android
 			// aapt resource value: 0x7f020000
 			public const int Icon = 2130837504;
 			
+			// aapt resource value: 0x7f020001
+			public const int monoandroidsplash = 2130837505;
+			
 			static Drawable()
 			{
 				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
@@ -61,23 +64,23 @@ namespace Playground.Android
 		public partial class Id
 		{
 			
-			// aapt resource value: 0x7f050001
-			public const int cancelButton = 2131034113;
+			// aapt resource value: 0x7f060001
+			public const int cancelButton = 2131099649;
 			
-			// aapt resource value: 0x7f050000
-			public const int doIt = 2131034112;
+			// aapt resource value: 0x7f060000
+			public const int doIt = 2131099648;
 			
-			// aapt resource value: 0x7f050004
-			public const int md5sum = 2131034116;
+			// aapt resource value: 0x7f060004
+			public const int md5sum = 2131099652;
 			
-			// aapt resource value: 0x7f050005
-			public const int progress = 2131034117;
+			// aapt resource value: 0x7f060005
+			public const int progress = 2131099653;
 			
-			// aapt resource value: 0x7f050003
-			public const int result = 2131034115;
+			// aapt resource value: 0x7f060003
+			public const int result = 2131099651;
 			
-			// aapt resource value: 0x7f050002
-			public const int status = 2131034114;
+			// aapt resource value: 0x7f060002
+			public const int status = 2131099650;
 			
 			static Id()
 			{
@@ -123,6 +126,22 @@ namespace Playground.Android
 			}
 			
 			private String()
+			{
+			}
+		}
+		
+		public partial class Style
+		{
+			
+			// aapt resource value: 0x7f050000
+			public const int Mono_Android_Theme_Splash = 2131034112;
+			
+			static Style()
+			{
+				global::Android.Runtime.ResourceIdManager.UpdateIdValues();
+			}
+			
+			private Style()
 			{
 			}
 		}

--- a/src/Playground.iOS/Playground_iOSViewController.cs
+++ b/src/Playground.iOS/Playground_iOSViewController.cs
@@ -81,14 +81,21 @@ namespace Playground.iOS
             st.Start();
             try {
                 handler.DisableCaching = true;
-                //var url = "https://github.com/paulcbetts/ModernHttpClient/releases/download/0.9.0/ModernHttpClient-0.9.zip";
-                var url = "https://github.com/downloads/nadlabak/android/cm-9.1.0a-umts_sholes.zip";
+                var url = "https://github.com/paulcbetts/ModernHttpClient/releases/download/0.9.0/ModernHttpClient-0.9.zip";
+             
 
                 var request = new HttpRequestMessage(HttpMethod.Get, url);
                 handler.RegisterForProgress(request, HandleDownloadProgress);
 
+                //if using NTLM authentication pass the credentials below
+                //handler.Credentials = new NetworkCredential("user","pass");
+
                 resp = await client.SendAsync(request, HttpCompletionOption.ResponseHeadersRead, currentToken.Token);
                 result.Text = "Got the headers!";
+
+                Console.WriteLine("Status code: {0}", resp.StatusCode);
+
+                Console.WriteLine("Reason: {0}", resp.ReasonPhrase);
 
                 Console.WriteLine("Headers");
                 foreach (var v in resp.Headers) {


### PR DESCRIPTION
I did the necessary changes to the repository to enable NTLM support for iOS. I tested this with my internal Sharepoint site. I don't think there is any automatic way to test this.

More details in this [issue](https://github.com/paulcbetts/ModernHttpClient/issues/170)
