### PR TITLE
Some changes to use the OkHttp NuGet instead of the embedded version

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@ build/
 *.userprefs
 build/
 *.xam
+packages

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,0 @@
-[submodule "vendor/okhttp"]
-	path = vendor/okhttp
-	url = https://github.com/paulcbetts/OkHttp-Xamarin.git

--- a/Makefile
+++ b/Makefile
@@ -8,28 +8,20 @@ package: ModernHttpClient.iOS.dll ModernHttpClient.iOS64.dll ModernHttpClient.An
 	mono vendor/nuget/NuGet.exe pack ./ModernHttpClient.nuspec
 	mv modernhttpclient*.nupkg ./build/
 
-submodule:
-	git submodule sync
-	git submodule update --init --recursive
-
-OkHttp.dll: submodule
-	$(MDTOOL) build -c:Release ./vendor/okhttp/OkHttp/OkHttp.csproj
-	cp ./vendor/okhttp/OkHttp/bin/Release/OkHttp.dll ./vendor/okhttp/OkHttp.dll
-
-ModernHttpClient.Android.dll: OkHttp.dll
+ModernHttpClient.Android.dll: 
 	$(MDTOOL) build -c:Release ./src/ModernHttpClient/ModernHttpClient.Android.csproj
 	mkdir -p ./build/MonoAndroid
-	mv ./src/ModernHttpClient/bin/Release/MonoAndroid/* ./build/MonoAndroid
+	mv ./src/ModernHttpClient/bin/Release/MonoAndroid/Modern* ./build/MonoAndroid
 
 ModernHttpClient.iOS.dll:
 	$(MDTOOL) build -c:Release ./src/ModernHttpClient/ModernHttpClient.iOS.csproj
 	mkdir -p ./build/MonoTouch
-	mv ./src/ModernHttpClient/bin/Release/MonoTouch/* ./build/MonoTouch
+	mv ./src/ModernHttpClient/bin/Release/MonoTouch/Modern* ./build/MonoTouch
 
 ModernHttpClient.iOS64.dll:
 	$(MDTOOL) build -c:Release ./src/ModernHttpClient/ModernHttpClient.iOS64.csproj
 	mkdir -p ./build/Xamarin.iOS10
-	mv ./src/ModernHttpClient/bin/Release/Xamarin.iOS10/* ./build/Xamarin.iOS10
+	mv ./src/ModernHttpClient/bin/Release/Xamarin.iOS10/Modern* ./build/Xamarin.iOS10
 
 ModernHttpClient.Portable.dll:
 	$(MDTOOL) build -c:Release ./src/ModernHttpClient/ModernHttpClient.Portable.csproj

--- a/ModernHttpClient.nuspec
+++ b/ModernHttpClient.nuspec
@@ -12,6 +12,9 @@
     <description>Write your app using System.Net.Http, but drop this library in and it will go drastically faster.</description>
     <summary>Write your app using System.Net.Http, but drop this library in and it will go drastically faster.</summary>
     <copyright>Copyright Paul Betts © 2012</copyright>
+    <dependencies>
+      <dependency id="Square.OkHttp" version="2.4.0.3" />
+    </dependencies>
   </metadata>
 
   <files>

--- a/component/component.yaml
+++ b/component/component.yaml
@@ -18,8 +18,16 @@ libraries:
   ios-unified: 
     - ../build/Xamarin.iOS10/ModernHttpClient.dll
   android:
-    - ../build/MonoAndroid/OkHttp.dll
     - ../build/MonoAndroid/ModernHttpClient.dll
+is_shell: true
+packages:
+  android:
+    - Square.OkHttp, Version=2.4.0.3
+    - modernhttpclient, Version=2.4.2
+  ios:
+    - modernhttpclient, Version=2.4.2
+  ios-unified:
+    - modernhttpclient, Version=2.4.2
 samples: 
   - name: "HttpClient.iOS Unified API Sample"
     path: ../samples/HttpClient.iOS/HttpClient.iOS.sln

--- a/samples/HttpClient.Android/HttpClient.Android.csproj
+++ b/samples/HttpClient.Android/HttpClient.Android.csproj
@@ -38,7 +38,7 @@
     <WarningLevel>4</WarningLevel>
     <AndroidUseSharedRuntime>false</AndroidUseSharedRuntime>
     <ConsolePause>false</ConsolePause>
-    <AndroidSupportedAbis>armeabi,armeabi-v7a</AndroidSupportedAbis>
+    <AndroidSupportedAbis>armeabi;armeabi-v7a;x86;arm64-v8a;x86_64</AndroidSupportedAbis>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />
@@ -46,11 +46,14 @@
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
     <Reference Include="System.Net.Http" />
-    <Reference Include="ModernHttpClient.Android">
+    <Reference Include="ModernHttpClient">
       <HintPath>..\..\build\MonoAndroid\ModernHttpClient.dll</HintPath>
     </Reference>
-    <Reference Include="OkHttp">
-      <HintPath>..\..\build\MonoAndroid\OkHttp.dll</HintPath>
+    <Reference Include="Square.OkIO">
+      <HintPath>packages\Square.OkIO.1.5.0.0\lib\MonoAndroid\Square.OkIO.dll</HintPath>
+    </Reference>
+    <Reference Include="Square.OkHttp">
+      <HintPath>packages\Square.OkHttp.2.4.0.3\lib\MonoAndroid\Square.OkHttp.dll</HintPath>
     </Reference>
   </ItemGroup>
   <ItemGroup>
@@ -65,6 +68,7 @@
     <None Include="Resources\AboutResources.txt" />
     <None Include="Assets\AboutAssets.txt" />
     <None Include="Properties\AndroidManifest.xml" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\Main.axml" />

--- a/samples/HttpClient.Android/Properties/AndroidManifest.xml
+++ b/samples/HttpClient.Android/Properties/AndroidManifest.xml
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android" android:versionCode="1" android:versionName="1.0" package="HttpClient.Android">
-	<uses-sdk android:minSdkVersion="8" />
-	<application android:label="HttpClient.Android">
+	<uses-sdk android:minSdkVersion="10" android:targetSdkVersion="10" />
+	<application android:label="HttpClient.Android" android:icon="@drawable/icon">
 	</application>
-    <uses-permission android:name="android.permission.INTERNET" />
+	<uses-permission android:name="android.permission.INTERNET" />
 </manifest>

--- a/samples/HttpClient.Android/packages.config
+++ b/samples/HttpClient.Android/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Square.OkHttp" version="2.4.0.3" targetFramework="MonoAndroid23" />
+  <package id="Square.OkIO" version="1.5.0.0" targetFramework="MonoAndroid23" />
+</packages>

--- a/samples/HttpClient.iOS/HttpClient.csproj
+++ b/samples/HttpClient.iOS/HttpClient.csproj
@@ -22,10 +22,10 @@
     <WarningLevel>4</WarningLevel>
     <MtouchDebug>True</MtouchDebug>
     <MtouchLink>None</MtouchLink>
-    <MtouchSdkVersion>7.0</MtouchSdkVersion>
     <MtouchI18n>
     </MtouchI18n>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>i386, x86_64</MtouchArch>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhoneSimulator' ">
     <DebugType>none</DebugType>
@@ -34,6 +34,11 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <MtouchLink>None</MtouchLink>
+    <CodesignKey>iPhone Developer</CodesignKey>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <MtouchI18n>
+    </MtouchI18n>
+    <MtouchArch>i386, x86_64</MtouchArch>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Debug|iPhone' ">
     <DebugSymbols>True</DebugSymbols>
@@ -49,7 +54,8 @@
     </IpaPackageName>
     <MtouchI18n>
     </MtouchI18n>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARMv7, ARMv7s, ARM64</MtouchArch>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
   </PropertyGroup>
   <PropertyGroup Condition=" '$(Configuration)|$(Platform)' == 'Release|iPhone' ">
     <DebugType>none</DebugType>
@@ -58,7 +64,12 @@
     <ErrorReport>prompt</ErrorReport>
     <WarningLevel>4</WarningLevel>
     <CodesignKey>iPhone Developer</CodesignKey>
-    <MtouchArch>ARMv7, ARM64</MtouchArch>
+    <MtouchArch>ARMv7, ARMv7s, ARM64</MtouchArch>
+    <MtouchUseRefCounting>true</MtouchUseRefCounting>
+    <IpaPackageName>
+    </IpaPackageName>
+    <MtouchI18n>
+    </MtouchI18n>
   </PropertyGroup>
   <ItemGroup>
     <Reference Include="System" />

--- a/samples/HttpClient.iOS/Info.plist
+++ b/samples/HttpClient.iOS/Info.plist
@@ -28,5 +28,19 @@
 		<string>UIInterfaceOrientationLandscapeLeft</string>
 		<string>UIInterfaceOrientationLandscapeRight</string>
 	</array>
+	<key>UISupportedInterfaceOrientations~ipad</key>
+	<array>
+		<string>UIInterfaceOrientationPortrait</string>
+		<string>UIInterfaceOrientationLandscapeLeft</string>
+		<string>UIInterfaceOrientationLandscapeRight</string>
+	</array>
+	<key>CFBundleIdentifier</key>
+	<string>com.modernhttpclient.httpclient</string>
+	<key>CFBundleDisplayName</key>
+	<string>HttpClient</string>
+	<key>CFBundleShortVersionString</key>
+	<string>1.0</string>
+	<key>CFBundleVersion</key>
+	<string>1.0</string>
 </dict>
 </plist>

--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -5,7 +5,7 @@ using System.Collections.Generic;
 using System.Linq;
 using System.Net;
 using System.Net.Http;
-using OkHttp;
+using Square.OkHttp;
 using Javax.Net.Ssl;
 using System.Text.RegularExpressions;
 using Java.IO;

--- a/src/ModernHttpClient/ModernHttpClient.Android.csproj
+++ b/src/ModernHttpClient/ModernHttpClient.Android.csproj
@@ -54,12 +54,16 @@
     <Folder Include="Properties\" />
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="ProgressStreamContent.cs" />
-    <Reference Include="OkHttp">
-      <HintPath>..\..\vendor\okhttp\OkHttp.dll</HintPath>
-    </Reference>
     <Compile Include="Utility.cs" />
     <Compile Include="CaptiveNetworkException.cs" />
     <Compile Include="Android\NativeCookieHandler.cs" />
+    <Reference Include="Square.OkIO">
+      <HintPath>..\..\packages\Square.OkIO.1.5.0.0\lib\MonoAndroid\Square.OkIO.dll</HintPath>
+    </Reference>
+    <None Include="packages.config" />
+    <Reference Include="Square.OkHttp">
+      <HintPath>..\..\packages\Square.OkHttp.2.4.0.3\lib\MonoAndroid\Square.OkHttp.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath)\Novell\Novell.MonoDroid.CSharp.targets" />
 </Project>

--- a/src/ModernHttpClient/packages.config
+++ b/src/ModernHttpClient/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Square.OkHttp" version="2.4.0.3" targetFramework="MonoAndroid23" />
+  <package id="Square.OkIO" version="1.5.0.0" targetFramework="MonoAndroid23" />
+</packages>

--- a/src/Playground.Android/Playground.Android.csproj
+++ b/src/Playground.Android/Playground.Android.csproj
@@ -50,10 +50,13 @@
     <Reference Include="System.Xml" />
     <Reference Include="System.Core" />
     <Reference Include="Mono.Android" />
-    <Reference Include="OkHttp">
-      <HintPath>..\..\vendor\okhttp\OkHttp.dll</HintPath>
-    </Reference>
     <Reference Include="System.Net.Http" />
+    <Reference Include="Square.OkIO">
+      <HintPath>..\..\packages\Square.OkIO.1.5.0.0\lib\MonoAndroid\Square.OkIO.dll</HintPath>
+    </Reference>
+    <Reference Include="Square.OkHttp">
+      <HintPath>..\..\packages\Square.OkHttp.2.4.0.3\lib\MonoAndroid\Square.OkHttp.dll</HintPath>
+    </Reference>
   </ItemGroup>
   <ItemGroup>
     <Compile Include="MainActivity.cs" />
@@ -64,6 +67,7 @@
     <None Include="Resources\AboutResources.txt" />
     <None Include="Assets\AboutAssets.txt" />
     <None Include="Properties\AndroidManifest.xml" />
+    <None Include="packages.config" />
   </ItemGroup>
   <ItemGroup>
     <AndroidResource Include="Resources\layout\Main.axml" />

--- a/src/Playground.Android/packages.config
+++ b/src/Playground.Android/packages.config
@@ -1,0 +1,5 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<packages>
+  <package id="Square.OkHttp" version="2.4.0.3" targetFramework="MonoAndroid403" />
+  <package id="Square.OkIO" version="1.5.0.0" targetFramework="MonoAndroid403" />
+</packages>


### PR DESCRIPTION
 - Using the Square.OkHttp NuGet instead of embedding the jar
    - embedding the jar causes conflicts when other libraries use OkHttp
    - a public version can be better consumed by others
 - Make the component include the NuGet installation
    - xamarin components can have the option to rather install NuGets instead of using the bundled dll
 - Updated the sample project files
    - just a few changes as a result of Xamarin updates

I removed the okhttp binding submodule as it is no longer needed. The NuGet OkHttp version is 2.4.0, the latest stable version.