### PR TITLE
Make sure we only include OkHttp on Android

### DIFF
--- a/ModernHttpClient.nuspec
+++ b/ModernHttpClient.nuspec
@@ -13,7 +13,9 @@
     <summary>Write your app using System.Net.Http, but drop this library in and it will go drastically faster.</summary>
     <copyright>Copyright Paul Betts © 2012</copyright>
     <dependencies>
-      <dependency id="Square.OkHttp" version="2.4.0.3" />
+      <group targetFramework="MonoAndroid">
+        <dependency id="Square.OkHttp" version="2.4.0.3" />
+      </group>
     </dependencies>
   </metadata>
 


### PR DESCRIPTION
As mentioned in PR #177, we should only include the dependency for Android