### PR TITLE
Fixes issue where ServicePointManager.ServerCertificateValidationCallback has invalid params

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -297,20 +297,22 @@ namespace ModernHttpClient
                     goto sslErrorVerify;
                 }
 
+                var netCerts = Enumerable.Range(0, serverCertChain.Count)
+                    .Select(x => serverCertChain[x].ToX509Certificate2())
+                    .ToArray();
+
+                root = netCerts[0];
+
+                chain.Build(root);
+
                 if (serverCertChain.Count == 1) {
                     errors = SslPolicyErrors.RemoteCertificateChainErrors;
                     goto sslErrorVerify;
                 }
 
-                var netCerts = Enumerable.Range(0, serverCertChain.Count)
-                    .Select(x => serverCertChain[x].ToX509Certificate2())
-                    .ToArray();
-
                 for (int i = 1; i < netCerts.Length; i++) {
                     chain.ChainPolicy.ExtraStore.Add(netCerts[i]);
                 }
-
-                root = netCerts[0];
 
                 chain.ChainPolicy.RevocationFlag = X509RevocationFlag.EntireChain;
                 chain.ChainPolicy.RevocationMode = X509RevocationMode.NoCheck;


### PR DESCRIPTION
In testing this I am hitting an endpoint that has a custom SSL Certificate that is basically self-issued. It's not trusted by any root CA's. Because of this, I wanted to invoke the callback with `ServicePointManager.ServerCertificateValidationCallback`. However, when this was called, I was receiving params that contained both the cert and chain as null values, so there was nothing for me to validate. This was due to there only being 1 certificate in the chain and your method was jumping ahead before it set the params to pass.

I modified it so that the params are set before the method jumps ahead.
