### PR TITLE
Make it clear Cookies in NativeCookieHandler are not to be changed.

### DIFF
--- a/src/ModernHttpClient/Android/NativeCookieHandler.cs
+++ b/src/ModernHttpClient/Android/NativeCookieHandler.cs
@@ -21,7 +21,7 @@ namespace ModernHttpClient
             }
         }
             
-        public List<Cookie> Cookies {
+        public IReadOnlyList<Cookie> Cookies {
             get {
                 return cookieManager.CookieStore.Cookies
                     .Select(ToNetCookie)

--- a/src/ModernHttpClient/Facades.cs
+++ b/src/ModernHttpClient/Facades.cs
@@ -77,7 +77,7 @@ namespace ModernHttpClient
             throw new Exception(wrongVersion);
         }
 
-        public List<Cookie> Cookies {
+        public IReadOnlyList<Cookie> Cookies {
             get { throw new Exception(wrongVersion); }
         }
     }

--- a/src/ModernHttpClient/iOS/NativeCookieHandler.cs
+++ b/src/ModernHttpClient/iOS/NativeCookieHandler.cs
@@ -19,7 +19,7 @@ namespace ModernHttpClient
             }
         }
 
-        public List<Cookie> Cookies {
+        public IReadOnlyList<Cookie> Cookies {
             get {
                 return NSHttpCookieStorage.SharedStorage.Cookies
                     .Select(ToNetCookie)


### PR DESCRIPTION
Making the Cookies property in NativeCookieHandler an IReadOnlyList makes it clearer that you can't set cookies by adding one to the list.