### PR TITLE
Portable versions of NativeMessageHandler and NativeCookieHandler

### DIFF
--- a/src/ModernHttpClient/Android/NativeCookieHandler.cs
+++ b/src/ModernHttpClient/Android/NativeCookieHandler.cs
@@ -21,7 +21,7 @@ namespace ModernHttpClient
             }
         }
             
-        public List<Cookie> Cookies {
+        public IReadOnlyList<Cookie> Cookies {
             get {
                 return cookieManager.CookieStore.Cookies
                     .Select(ToNetCookie)

--- a/src/ModernHttpClient/Facades.cs
+++ b/src/ModernHttpClient/Facades.cs
@@ -1,51 +1,9 @@
 ﻿using System;
-using System.Collections.Generic;
 using System.Net.Http;
-using System.Threading.Tasks;
-using System.Threading;
 using System.IO;
-using System.Net;
 
 namespace ModernHttpClient
 {
-    public class NativeMessageHandler : HttpClientHandler
-    {
-        const string wrongVersion = "You're referencing the Portable version in your App - you need to reference the platform (iOS/Android) version";
-
-        public bool DisableCaching { get; set; }
-
-        /// <summary>
-        /// Initializes a new instance of the <see
-        /// cref="ModernHttpClient.Portable.NativeMessageHandler"/> class.
-        /// </summary>
-        public NativeMessageHandler(): base()
-        {
-        }
-
-        /// <summary>
-        /// Initializes a new instance of the <see
-        /// cref="ModernHttpClient.Portable.NativeMessageHandler"/> class.
-        /// </summary>
-        /// <param name="throwOnCaptiveNetwork">If set to <c>true</c> throw on
-        /// captive network (ie: a captive network is usually a wifi network
-        /// where an authentication html form is shown instead of the real
-        /// content).</param>
-        /// <param name="customSSLVerification">Enable custom SSL certificate 
-        /// verification via ServicePointManager. Disabled by default for 
-        /// performance reasons (i.e. the OS default certificate verification 
-        /// will take place)</param>
-        /// <param name="cookieHandler">Enable native cookie handling.
-        /// </param>
-        public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification, NativeCookieHandler cookieHandler = null) : base()
-        {
-        }
-
-        public void RegisterForProgress(HttpRequestMessage request, ProgressDelegate callback)
-        {
-            throw new Exception(wrongVersion);
-        }
-    }
-
     public class ProgressStreamContent : StreamContent 
     {
         const string wrongVersion = "You're referencing the Portable version in your App - you need to reference the platform (iOS/Android) version";
@@ -67,18 +25,4 @@ namespace ModernHttpClient
     }
 
     public delegate void ProgressDelegate(long bytes, long totalBytes, long totalBytesExpected);
-
-    public class NativeCookieHandler
-    {
-        const string wrongVersion = "You're referencing the Portable version in your App - you need to reference the platform (iOS/Android) version";
-
-        public void SetCookies(IEnumerable<Cookie> cookies)
-        {
-            throw new Exception(wrongVersion);
-        }
-
-        public IReadOnlyList<Cookie> Cookies {
-            get { throw new Exception(wrongVersion); }
-        }
-    }
 }

--- a/src/ModernHttpClient/Facades.cs
+++ b/src/ModernHttpClient/Facades.cs
@@ -77,7 +77,7 @@ namespace ModernHttpClient
             throw new Exception(wrongVersion);
         }
 
-        public List<Cookie> Cookies {
+        public IReadOnlyList<Cookie> Cookies {
             get { throw new Exception(wrongVersion); }
         }
     }

--- a/src/ModernHttpClient/ModernHttpClient.Portable.csproj
+++ b/src/ModernHttpClient/ModernHttpClient.Portable.csproj
@@ -37,6 +37,8 @@
     <Compile Include="Properties\AssemblyInfo.cs" />
     <Compile Include="Facades.cs" />
     <Compile Include="CaptiveNetworkException.cs" />
+    <Compile Include="NativeCookieHandler.cs" />
+    <Compile Include="NativeMessageHandler.cs" />
   </ItemGroup>
   <Import Project="$(MSBuildExtensionsPath32)\Microsoft\Portable\$(TargetFrameworkVersion)\Microsoft.Portable.CSharp.targets" />
   <ItemGroup>

--- a/src/ModernHttpClient/NativeCookieHandler.cs
+++ b/src/ModernHttpClient/NativeCookieHandler.cs
@@ -1,0 +1,53 @@
+﻿using System;
+using System.Collections.Generic;
+using System.Linq;
+using System.Net;
+using System.Text;
+
+namespace ModernHttpClient
+{
+    public class NativeCookieHandler
+    {
+        static readonly char[] PortDelimiters = new[] { ',', '"' };
+
+        readonly HashSet<string> authorities = new HashSet<string>(StringComparer.Ordinal);
+        internal readonly CookieContainer CookieContainer = new CookieContainer();
+
+        public void SetCookies(IEnumerable<Cookie> cookies)
+        {
+            foreach (var cookie in cookies) {
+                var uriSb = new StringBuilder();
+                uriSb.Append(cookie.Secure ? "https://" : "http://");
+                uriSb.Append(cookie.Domain);
+                if (cookie.Port.Length > 0) {
+                    var ports = cookie.Port.Split(PortDelimiters, StringSplitOptions.RemoveEmptyEntries);
+                    if (ports.Length > 0) uriSb.Append(':').Append(ports[0]);
+                }
+                uriSb.Append(cookie.Path);
+
+                Uri uri;
+                if (!Uri.TryCreate(uriSb.ToString(), UriKind.Absolute, out uri)) {
+                    throw new CookieException();
+                }
+
+                CookieContainer.Add(uri, cookie);
+                Add(uri);
+            }
+        }
+
+        public IReadOnlyList<Cookie> Cookies {
+            get {
+                var cookies = new CookieCollection();
+                foreach (var uri in authorities.Select(a => new Uri("https://" + a))) {
+                    cookies.Add(CookieContainer.GetCookies(uri));
+                }
+                return cookies.Cast<Cookie>().ToList();
+            }
+        }
+
+        internal void Add(Uri uri)
+        {
+            authorities.Add(uri.Authority);
+        }
+    }
+}

--- a/src/ModernHttpClient/NativeMessageHandler.cs
+++ b/src/ModernHttpClient/NativeMessageHandler.cs
@@ -1,0 +1,68 @@
+﻿using System;
+using System.Net.Http;
+using System.Threading;
+using System.Threading.Tasks;
+
+namespace ModernHttpClient
+{
+    public class NativeMessageHandler : HttpClientHandler
+    {
+        const string wrongVersion = "You're referencing the Portable version in your App - you need to reference the platform (iOS/Android) version";
+
+        readonly bool throwOnCaptiveNetwork;
+        readonly NativeCookieHandler cookieHandler;
+
+        /// <summary>
+        /// Initializes a new instance of the <see
+        /// cref="ModernHttpClient.Portable.NativeMessageHandler"/> class.
+        /// </summary>
+        public NativeMessageHandler(): this(false, false)
+        {
+        }
+
+        /// <summary>
+        /// Initializes a new instance of the <see
+        /// cref="ModernHttpClient.Portable.NativeMessageHandler"/> class.
+        /// </summary>
+        /// <param name="throwOnCaptiveNetwork">If set to <c>true</c> throw on
+        /// captive network (ie: a captive network is usually a wifi network
+        /// where an authentication html form is shown instead of the real
+        /// content).</param>
+        /// <param name="customSSLVerification">Enable custom SSL certificate 
+        /// verification via ServicePointManager. Disabled by default for 
+        /// performance reasons (i.e. the OS default certificate verification 
+        /// will take place)</param>
+        /// <param name="cookieHandler">Enable native cookie handling.
+        /// </param>
+        public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification, NativeCookieHandler cookieHandler = null) : base()
+        {
+            this.throwOnCaptiveNetwork = throwOnCaptiveNetwork;
+            this.cookieHandler = cookieHandler;
+
+            UseCookies = cookieHandler != null;
+            if (cookieHandler != null) {
+                CookieContainer = cookieHandler.CookieContainer;
+            }
+        }
+
+        public bool DisableCaching { get; set; }
+
+        public void RegisterForProgress(HttpRequestMessage request, ProgressDelegate callback)
+        {
+            throw new Exception(wrongVersion);
+        }
+
+        protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
+        {
+            var reqUri = request.RequestUri;
+            var response = await base.SendAsync(request, cancellationToken);
+            var newUri = response.RequestMessage.RequestUri;
+            if (throwOnCaptiveNetwork && reqUri.Host != newUri.Host) {
+                throw new CaptiveNetworkException(reqUri, newUri);
+            }
+            cookieHandler.Add(reqUri);
+            cookieHandler.Add(newUri);
+            return response;
+        }
+    }
+}

--- a/src/ModernHttpClient/iOS/NativeCookieHandler.cs
+++ b/src/ModernHttpClient/iOS/NativeCookieHandler.cs
@@ -19,7 +19,7 @@ namespace ModernHttpClient
             }
         }
 
-        public List<Cookie> Cookies {
+        public IReadOnlyList<Cookie> Cookies {
             get {
                 return NSHttpCookieStorage.SharedStorage.Cookies
                     .Select(ToNetCookie)


### PR DESCRIPTION
This is a first try at fixing #188. Adapted from #175.

`NativeCookieHandler` mostly works, though API mismatches forces us to jump through some hoops.
I based this off #187, which I think is a good idea?

`NativeMessageHandler` still has some gaps:
- `throwOnCaptiveNetwork` works;
- `customSSLVerification` doesn't seem to require anything special;
- `DisableCaching` would require inheriting from `WebRequestHandler` is isn't portable;
- `RegisterForProgress` is yet to be done.

Any feedback would be greatly appreciated.