### PR TITLE
added timeout property and implemented the property in both OkHttpNetworkHandler and NSUrlSessionHandler       

### DIFF
--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -29,6 +29,7 @@ namespace ModernHttpClient
             };
 
         public bool DisableCaching { get; set; }
+        public TimeSpan? Timeout { get; set; }
 
         public NativeMessageHandler() : this(false, false) {}
 
@@ -79,6 +80,14 @@ namespace ModernHttpClient
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (Timeout != null)
+            {
+                var timeout = (long)TimeOut.Value.TotalMilliseconds;
+                client.SetConnectTimeout((long)timeout, TimeUnit.Milliseconds);
+                client.SetWriteTimeout((long)timeout, TimeUnit.Milliseconds);
+                client.SetReadTimeout((long)timeout, TimeUnit.Milliseconds);
+            }
+
             var java_uri = request.RequestUri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);
             var url = new Java.Net.URL(java_uri);
 

--- a/src/ModernHttpClient/Facades.cs
+++ b/src/ModernHttpClient/Facades.cs
@@ -40,6 +40,12 @@ namespace ModernHttpClient
         {
         }
 
+        public TimeSpan? Timeout
+        {
+            get {throw new Exception(wrongVersion);}
+            set { throw new Exception(wrongVersion);}
+        }
+
         public void RegisterForProgress(HttpRequestMessage request, ProgressDelegate callback)
         {
             throw new Exception(wrongVersion);

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -32,7 +32,7 @@ namespace ModernHttpClient
         public CancellationToken CancellationToken { get; set; }
         public bool IsCompleted { get; set; }
     }
-
+     
     public class NativeMessageHandler : HttpClientHandler
     {
         readonly NSUrlSession session;
@@ -52,6 +52,7 @@ namespace ModernHttpClient
         readonly bool customSSLVerification;
 
         public bool DisableCaching { get; set; }
+        public TimeSpan? Timeout { get; set; }
 
         public NativeMessageHandler(): this(false, false) { }
         public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification, NativeCookieHandler cookieHandler = null, SslProtocol? minimumSSLProtocol = null)
@@ -128,6 +129,9 @@ namespace ModernHttpClient
                 HttpMethod = request.Method.ToString().ToUpperInvariant(),
                 Url = NSUrl.FromString(request.RequestUri.AbsoluteUri),
             };
+
+            if (Timeout != null)
+                rq.TimeoutInterval = Timeout.Value.Seconds;
 
             var op = session.CreateDataTask(rq);
 


### PR DESCRIPTION
Ran into issues with our implementation of ModernHttpClient not properly obeying our set timeout interval in iOS.  Since we don't have access to the client directly here the best option seemed to be to add a new property and passing that down into the respective request handlers for each platform.