### PR TITLE
Issue #173 -- Enabling TLS 1.1 & 1.2 on Android Versions prior to Lollipop

### DIFF
--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -38,6 +38,12 @@ namespace ModernHttpClient
 
             if (customSSLVerification) client.SetHostnameVerifier(new HostnameVerifier());
             noCacheCacheControl = (new CacheControl.Builder()).NoCache().Build();
+
+			// If less than Android Lollipop
+			if (((int)Build.VERSION.SdkInt) < 21)
+            {
+                client.SetSslSocketFactory(new TlsSSLSocketFactory());
+            }
         }
 
         public void RegisterForProgress(HttpRequestMessage request, ProgressDelegate callback)

--- a/src/ModernHttpClient/Android/TlsSSLSocketFactory.cs
+++ b/src/ModernHttpClient/Android/TlsSSLSocketFactory.cs
@@ -1,0 +1,73 @@
+using Javax.Net.Ssl;
+
+namespace ModernHttpClient
+{
+
+    public class TlsSSLSocketFactory : SSLSocketFactory
+    {
+        readonly SSLSocketFactory factory = (SSLSocketFactory)Default;
+
+        public override string[] GetDefaultCipherSuites()
+        {
+            return factory.GetDefaultCipherSuites();
+        }
+
+        public override string[] GetSupportedCipherSuites()
+        {
+            return factory.GetSupportedCipherSuites();
+        }
+        public override Java.Net.Socket CreateSocket(Java.Net.InetAddress address, int port, Java.Net.InetAddress localAddress, int localPort)
+        {
+            SSLSocket socket = (SSLSocket)factory.CreateSocket(address, port, localAddress, localPort);
+            socket.SetEnabledProtocols(socket.GetSupportedProtocols());
+
+            return socket;
+        }
+
+        public override Java.Net.Socket CreateSocket(Java.Net.InetAddress host, int port)
+        {
+            SSLSocket socket = (SSLSocket)factory.CreateSocket(host, port);
+            socket.SetEnabledProtocols(socket.GetSupportedProtocols());
+
+            return socket;
+        }
+
+        public override Java.Net.Socket CreateSocket(string host, int port, Java.Net.InetAddress localHost, int localPort)
+        {
+            SSLSocket socket = (SSLSocket)factory.CreateSocket(host, port, localHost, localPort);
+            socket.SetEnabledProtocols(socket.GetSupportedProtocols());
+
+            return socket;
+        }
+
+        public override Java.Net.Socket CreateSocket(string host, int port)
+        {
+            SSLSocket socket = (SSLSocket)factory.CreateSocket(host, port);
+            socket.SetEnabledProtocols(socket.GetSupportedProtocols());
+
+            return socket;
+        }
+
+        public override Java.Net.Socket CreateSocket(Java.Net.Socket s, string host, int port, bool autoClose)
+        {
+            SSLSocket socket = (SSLSocket)factory.CreateSocket(s, host, port, autoClose);
+            socket.SetEnabledProtocols(socket.GetSupportedProtocols());
+
+            return socket;
+        }
+
+        protected override void Dispose(bool disposing)
+        {
+            factory.Dispose();
+            base.Dispose(disposing);
+        }
+
+        public override Java.Net.Socket CreateSocket()
+        {
+            SSLSocket socket = (SSLSocket)factory.CreateSocket();
+            socket.SetEnabledProtocols(socket.GetSupportedProtocols());
+
+            return socket;
+        }
+    }
+}


### PR DESCRIPTION
Error when connecting from Android to a server that does not support
TLS 1.0