### PR TITLE
- Added checking of SubjectAltName entries to ssl remote certificate …

### DIFF
--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -330,7 +330,13 @@ namespace ModernHttpClient
 
                 var subject = root.Subject;
                 var subjectCn = cnRegex.Match(subject).Groups[1].Value;
+                bool match;
+                List<string> subjects;
 
+                match = false;
+                subjects = Utility.GetSans(root);
+                subjects.Insert(0, subjectCn);
+                for (int i = 0; i < subjects.Count; i++) {
                 if (String.IsNullOrWhiteSpace(subjectCn) || !Utility.MatchHostnameToPattern(task.CurrentRequest.Url.Host, subjectCn)) {
                     errors = SslPolicyErrors.RemoteCertificateNameMismatch;
                     goto sslErrorVerify;


### PR DESCRIPTION
The SSL subject verification code fails if the hostname is a SubjectAltName and not the CN of the certificate. This patch adds checking the hostname against SAN records. 

Sample explanation of SANs: https://www.digicert.com/subject-alternative-name-compatibility.htm