### PR TITLE
NSUrlSessionHandler: TimeoutInterval to TotalSeconds rather than Seconds

### DIFF
--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -83,9 +83,9 @@ namespace ModernHttpClient
             if (Timeout != null)
             {
                 var timeout = (long)TimeOut.Value.TotalMilliseconds;
-                client.SetConnectTimeout((long)timeout, TimeUnit.Milliseconds);
-                client.SetWriteTimeout((long)timeout, TimeUnit.Milliseconds);
-                client.SetReadTimeout((long)timeout, TimeUnit.Milliseconds);
+                client.SetConnectTimeout(timeout, TimeUnit.Milliseconds);
+                client.SetWriteTimeout(timeout, TimeUnit.Milliseconds);
+                client.SetReadTimeout(timeout, TimeUnit.Milliseconds);
             }
 
             var java_uri = request.RequestUri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);

--- a/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
+++ b/src/ModernHttpClient/Android/OkHttpNetworkHandler.cs
@@ -29,6 +29,7 @@ namespace ModernHttpClient
             };
 
         public bool DisableCaching { get; set; }
+        public TimeSpan? Timeout { get; set; }
 
         public NativeMessageHandler() : this(false, false) {}
 
@@ -79,6 +80,14 @@ namespace ModernHttpClient
 
         protected override async Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken cancellationToken)
         {
+            if (Timeout != null)
+            {
+                var timeout = (long)TimeOut.Value.TotalMilliseconds;
+                client.SetConnectTimeout((long)timeout, TimeUnit.Milliseconds);
+                client.SetWriteTimeout((long)timeout, TimeUnit.Milliseconds);
+                client.SetReadTimeout((long)timeout, TimeUnit.Milliseconds);
+            }
+
             var java_uri = request.RequestUri.GetComponents(UriComponents.AbsoluteUri, UriFormat.UriEscaped);
             var url = new Java.Net.URL(java_uri);
 

--- a/src/ModernHttpClient/Facades.cs
+++ b/src/ModernHttpClient/Facades.cs
@@ -40,6 +40,12 @@ namespace ModernHttpClient
         {
         }
 
+        public TimeSpan? Timeout
+        {
+            get {throw new Exception(wrongVersion);}
+            set { throw new Exception(wrongVersion);}
+        }
+
         public void RegisterForProgress(HttpRequestMessage request, ProgressDelegate callback)
         {
             throw new Exception(wrongVersion);

--- a/src/ModernHttpClient/Facades.cs
+++ b/src/ModernHttpClient/Facades.cs
@@ -43,7 +43,7 @@ namespace ModernHttpClient
         public TimeSpan? Timeout
         {
             get {throw new Exception(wrongVersion);}
-            set { throw new Exception(wrongVersion);}
+            set {throw new Exception(wrongVersion);}
         }
 
         public void RegisterForProgress(HttpRequestMessage request, ProgressDelegate callback)

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -131,7 +131,7 @@ namespace ModernHttpClient
             };
 
             if (Timeout != null)
-                rq.TimeoutInterval = Timeout.Value.Seconds;
+                rq.TimeoutInterval = Timeout.Value.TotalSeconds;
 
             var op = session.CreateDataTask(rq);
 

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -32,7 +32,7 @@ namespace ModernHttpClient
         public CancellationToken CancellationToken { get; set; }
         public bool IsCompleted { get; set; }
     }
-     
+
     public class NativeMessageHandler : HttpClientHandler
     {
         readonly NSUrlSession session;

--- a/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
+++ b/src/ModernHttpClient/iOS/NSUrlSessionHandler.cs
@@ -32,7 +32,7 @@ namespace ModernHttpClient
         public CancellationToken CancellationToken { get; set; }
         public bool IsCompleted { get; set; }
     }
-
+     
     public class NativeMessageHandler : HttpClientHandler
     {
         readonly NSUrlSession session;
@@ -52,6 +52,7 @@ namespace ModernHttpClient
         readonly bool customSSLVerification;
 
         public bool DisableCaching { get; set; }
+        public TimeSpan? Timeout { get; set; }
 
         public NativeMessageHandler(): this(false, false) { }
         public NativeMessageHandler(bool throwOnCaptiveNetwork, bool customSSLVerification, NativeCookieHandler cookieHandler = null, SslProtocol? minimumSSLProtocol = null)
@@ -128,6 +129,9 @@ namespace ModernHttpClient
                 HttpMethod = request.Method.ToString().ToUpperInvariant(),
                 Url = NSUrl.FromString(request.RequestUri.AbsoluteUri),
             };
+
+            if (Timeout != null)
+                rq.TimeoutInterval = Timeout.Value.Seconds;
 
             var op = session.CreateDataTask(rq);
 


### PR DESCRIPTION
The setting of:

rq.TimeoutInterval = Timeout.Value.Seconds;

Should be:

rq.TimeoutInterval = Timeout.Value.TotalSeconds;

so that the TimeoutInterval is set to the TimeSpan in seconds rather than the seconds part of the Timespan which would be zero for any whole minute.